### PR TITLE
Fix dashboard ticker search navigation

### DIFF
--- a/src/features/stock-dashboard/components/ChartPageClient.tsx
+++ b/src/features/stock-dashboard/components/ChartPageClient.tsx
@@ -27,6 +27,11 @@ export function ChartPageClient() {
   }, [symbol, selectedTicker, setSelectedTicker, router]);
 
   const activeTicker = symbol || selectedTicker;
+  const handleTickerSubmit = (ticker: string) => {
+    const nextSearchParams = new URLSearchParams(searchParams.toString());
+    nextSearchParams.set('symbol', ticker);
+    router.replace(`/dashboard/charts?${nextSearchParams.toString()}`);
+  };
 
   return (
     <div className='flex h-full flex-col gap-6'>
@@ -35,7 +40,7 @@ export function ChartPageClient() {
         <div className='flex items-center gap-4'>
           <QuoteProviderToggle />
           <div className='w-[300px]'>
-            <TickerInput />
+            <TickerInput onTickerSubmit={handleTickerSubmit} />
           </div>
         </div>
       </div>

--- a/src/features/stock-dashboard/components/TickerInput.tsx
+++ b/src/features/stock-dashboard/components/TickerInput.tsx
@@ -8,11 +8,11 @@ import { useDashboardStore } from '../store';
 import { mockStocks } from '@/lib/mock-data/stocks';
 
 interface TickerInputProps {
-  // Add any specific props here if needed
+  onTickerSubmit?: (ticker: string) => void;
 }
 
 export const TickerInput = forwardRef<HTMLInputElement, TickerInputProps>(
-  (props, ref) => {
+  ({ onTickerSubmit }, ref) => {
     const [ticker, setTicker] = useState('');
     const [error, setError] = useState<string | null>(null);
     const [isFocused, setIsFocused] = useState(false);
@@ -33,7 +33,11 @@ export const TickerInput = forwardRef<HTMLInputElement, TickerInputProps>(
         return;
       }
       const sym = normalizeTicker(ticker);
-      setSelectedTicker(sym);
+      if (onTickerSubmit) {
+        onTickerSubmit(sym);
+      } else {
+        setSelectedTicker(sym);
+      }
       setTicker('');
       setIsFocused(false);
       setError(null);

--- a/src/features/stock-dashboard/components/__tests__/chart-page-client.test.tsx
+++ b/src/features/stock-dashboard/components/__tests__/chart-page-client.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ChartPageClient } from '../ChartPageClient';
+import { useDashboardStore } from '../../store';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+jest.mock('../../store', () => ({
+  useDashboardStore: jest.fn()
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+  useSearchParams: jest.fn()
+}));
+
+jest.mock('../QuoteProviderToggle', () => ({
+  QuoteProviderToggle: () => <div>Quote Provider</div>
+}));
+
+jest.mock('../KLineChart', () => ({
+  KLineChart: ({ ticker }: { ticker: string }) => (
+    <div data-testid='kline-chart'>{ticker}</div>
+  )
+}));
+
+describe('ChartPageClient', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('replaces the symbol query param when searching from the charts page', () => {
+    const replace = jest.fn();
+    const setSelectedTicker = jest.fn();
+
+    (useRouter as jest.Mock).mockReturnValue({ replace });
+    (useSearchParams as jest.Mock).mockReturnValue({
+      get: (key: string) => (key === 'symbol' ? 'GOOGL' : null),
+      toString: () => 'symbol=GOOGL'
+    });
+    (useDashboardStore as unknown as jest.Mock).mockReturnValue({
+      selectedTicker: 'GOOGL',
+      setSelectedTicker,
+      quoteProvider: 'default'
+    });
+
+    render(<ChartPageClient />);
+
+    fireEvent.change(screen.getByLabelText('Enter stock ticker symbol'), {
+      target: { value: 'AAPL' }
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+
+    expect(replace).toHaveBeenCalledWith('/dashboard/charts?symbol=AAPL');
+    expect(setSelectedTicker).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Summary
- wire the chart page ticker input to replace the current query param instead of relying on store state
- add a regression test that asserts the new search behavior updates the router without calling `setSelectedTicker`

Testing
- Not run (not requested)