### PR TITLE
Add kline timeframe selector with interval-aware data flow

### DIFF
--- a/src/app/api/stocks/__tests__/request-fixtures.ts
+++ b/src/app/api/stocks/__tests__/request-fixtures.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from 'next/server';
+import type { NextRequest } from 'next/server';
 
 /**
  * Type definition for Next.js App Router dynamic route params

--- a/src/app/api/stocks/kline/[symbol]/__tests__/route.test.ts
+++ b/src/app/api/stocks/kline/[symbol]/__tests__/route.test.ts
@@ -36,7 +36,7 @@ jest.mock('next/server', () => ({
       };
     })
   },
-  NextRequest: jest.requireActual('next/server').NextRequest
+  NextRequest: class NextRequestMock {}
 }));
 
 jest.mock('@sentry/nextjs', () => ({
@@ -68,7 +68,7 @@ const mockSeries: KLineSeries = {
   range: {
     startDate: '2023-01-01T00:00:00.000Z',
     endDate: '2024-01-01T00:00:00.000Z',
-    interval: '1d'
+    interval: 'day'
   },
   candles: [
     {
@@ -115,6 +115,7 @@ describe('/api/stocks/kline/[symbol] API Route', () => {
     expect(responseData.data).toEqual(mockSeries);
     expect(mockStockServiceInstance.getKLineSeries).toHaveBeenCalledWith(
       'AAPL',
+      'day',
       CANONICAL_QUOTE_PROVIDER
     );
     expect(response.headers.get('Cache-Control')).toBe(
@@ -136,16 +137,20 @@ describe('/api/stocks/kline/[symbol] API Route', () => {
 
     expect(mockStockServiceInstance.getKLineSeries).toHaveBeenCalledWith(
       'AAPL',
+      'day',
       CANONICAL_QUOTE_PROVIDER
     );
   });
 
-  it('passes the legacy default alias through to the service layer', async () => {
+  it('passes the requested interval and legacy default alias through to the service layer', async () => {
     mockStockServiceInstance.getKLineSeries.mockResolvedValue(mockSeries);
 
     await GET(
       createMockRequest('http://localhost:3000/api/stocks/kline/AAPL', {
-        query: { provider: LEGACY_DEFAULT_QUOTE_PROVIDER }
+        query: {
+          provider: LEGACY_DEFAULT_QUOTE_PROVIDER,
+          interval: 'week'
+        }
       }),
       {
         params: createMockParams('AAPL').params
@@ -154,6 +159,7 @@ describe('/api/stocks/kline/[symbol] API Route', () => {
 
     expect(mockStockServiceInstance.getKLineSeries).toHaveBeenCalledWith(
       'AAPL',
+      'week',
       LEGACY_DEFAULT_QUOTE_PROVIDER
     );
   });
@@ -177,6 +183,25 @@ describe('/api/stocks/kline/[symbol] API Route', () => {
       code: 'INVALID_SYMBOL',
       message: 'Ticker symbol is required'
     });
+  });
+
+  it('returns 400 for invalid kline intervals', async () => {
+    const response = await GET(
+      createMockRequest('http://localhost:3000/api/stocks/kline/AAPL', {
+        query: { interval: 'quarter' }
+      }),
+      {
+        params: createMockParams('AAPL').params
+      }
+    );
+    const responseData: APIResponse<null> = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(responseData.error).toEqual({
+      code: 'INVALID_INTERVAL',
+      message: 'Unsupported kline interval: quarter'
+    });
+    expect(mockStockServiceInstance.getKLineSeries).not.toHaveBeenCalled();
   });
 
   it('returns 400 for the removed provider alias', async () => {

--- a/src/app/api/stocks/kline/[symbol]/__tests__/route.test.ts
+++ b/src/app/api/stocks/kline/[symbol]/__tests__/route.test.ts
@@ -36,6 +36,7 @@ jest.mock('next/server', () => ({
       };
     })
   },
+  // The route uses createMockRequest for request shape; this only satisfies the import.
   NextRequest: class NextRequestMock {}
 }));
 

--- a/src/app/api/stocks/kline/[symbol]/route.ts
+++ b/src/app/api/stocks/kline/[symbol]/route.ts
@@ -3,7 +3,13 @@ import * as Sentry from '@sentry/nextjs';
 import { CANONICAL_QUOTE_PROVIDER } from '@/lib/providers/config';
 import { getStockService } from '@/lib/services/stock-service';
 import { validateTicker, normalizeTicker } from '@/lib/validation/ticker';
-import { APIResponse, KLineSeries, APIError } from '@/lib/types/stock-api';
+import {
+  APIResponse,
+  APIError,
+  DEFAULT_KLINE_INTERVAL,
+  isKLineInterval,
+  KLineSeries
+} from '@/lib/types/stock-api';
 import { logger } from '@/lib/logger';
 
 const CACHE_HEADER = 'public, s-maxage=86400, stale-while-revalidate=604800';
@@ -50,9 +56,40 @@ export async function GET(
         const url = new URL(request.url);
         const provider =
           url.searchParams.get('provider') || CANONICAL_QUOTE_PROVIDER;
+        const rawInterval = url.searchParams.get('interval');
+        const interval = rawInterval?.toLowerCase();
+
+        if (rawInterval && !isKLineInterval(interval)) {
+          const error: APIError = {
+            code: 'INVALID_INTERVAL',
+            message: `Unsupported kline interval: ${rawInterval}`
+          };
+
+          logger.warn(`API Error: ${error.message}`, {
+            symbol,
+            code: error.code,
+            path: requestPath,
+            interval: rawInterval
+          });
+
+          const response: APIResponse<null> = {
+            success: false,
+            data: null,
+            error,
+            timestamp: new Date().toISOString()
+          };
+
+          return NextResponse.json(response, { status: 400 });
+        }
+
         span?.setAttribute('provider', provider);
+        span?.setAttribute('interval', interval || DEFAULT_KLINE_INTERVAL);
         const stockService = getStockService();
-        const series = await stockService.getKLineSeries(symbol, provider);
+        const series = await stockService.getKLineSeries(
+          symbol,
+          interval || DEFAULT_KLINE_INTERVAL,
+          provider
+        );
 
         span?.setAttribute('kline.candles', series.candles.length);
 
@@ -137,6 +174,7 @@ function isAPIError(error: unknown): error is APIError {
 function getStatusCodeForError(code: string): number {
   switch (code) {
     case 'INVALID_SYMBOL':
+    case 'INVALID_INTERVAL':
     case 'INVALID_PROVIDER':
       return 400;
     case 'API_LIMIT_EXCEEDED':

--- a/src/app/api/stocks/kline/[symbol]/route.ts
+++ b/src/app/api/stocks/kline/[symbol]/route.ts
@@ -57,9 +57,9 @@ export async function GET(
         const provider =
           url.searchParams.get('provider') || CANONICAL_QUOTE_PROVIDER;
         const rawInterval = url.searchParams.get('interval');
-        const interval = rawInterval?.toLowerCase();
+        const normalizedInterval = rawInterval?.toLowerCase();
 
-        if (rawInterval && !isKLineInterval(interval)) {
+        if (rawInterval && !isKLineInterval(normalizedInterval)) {
           const error: APIError = {
             code: 'INVALID_INTERVAL',
             message: `Unsupported kline interval: ${rawInterval}`
@@ -82,12 +82,16 @@ export async function GET(
           return NextResponse.json(response, { status: 400 });
         }
 
+        const interval = isKLineInterval(normalizedInterval)
+          ? normalizedInterval
+          : DEFAULT_KLINE_INTERVAL;
+
         span?.setAttribute('provider', provider);
-        span?.setAttribute('interval', interval || DEFAULT_KLINE_INTERVAL);
+        span?.setAttribute('interval', interval);
         const stockService = getStockService();
         const series = await stockService.getKLineSeries(
           symbol,
-          interval || DEFAULT_KLINE_INTERVAL,
+          interval,
           provider
         );
 

--- a/src/app/api/stocks/quote/[symbol]/__tests__/route.test.ts
+++ b/src/app/api/stocks/quote/[symbol]/__tests__/route.test.ts
@@ -36,6 +36,7 @@ jest.mock('next/server', () => ({
       };
     })
   },
+  // The route uses createMockRequest for request shape; this only satisfies the import.
   NextRequest: class NextRequestMock {}
 }));
 

--- a/src/app/api/stocks/quote/[symbol]/__tests__/route.test.ts
+++ b/src/app/api/stocks/quote/[symbol]/__tests__/route.test.ts
@@ -36,7 +36,7 @@ jest.mock('next/server', () => ({
       };
     })
   },
-  NextRequest: jest.requireActual('next/server').NextRequest
+  NextRequest: class NextRequestMock {}
 }));
 
 jest.mock('@sentry/nextjs', () => ({

--- a/src/features/stock-dashboard/components/ChartPageClient.tsx
+++ b/src/features/stock-dashboard/components/ChartPageClient.tsx
@@ -7,6 +7,34 @@ import { useDashboardStore } from '../store';
 import { KLineChart } from './KLineChart';
 import { TickerInput } from './TickerInput';
 import { Card, CardContent } from '@/components/ui/card';
+import {
+  DEFAULT_KLINE_INTERVAL,
+  isKLineInterval,
+  type KLineInterval
+} from '@/lib/types/stock-api';
+
+function buildChartsHref(
+  searchParams: URLSearchParams,
+  symbol?: string | null,
+  interval?: KLineInterval
+) {
+  const nextSearchParams = new URLSearchParams(searchParams.toString());
+
+  if (symbol) {
+    nextSearchParams.set('symbol', symbol);
+  } else {
+    nextSearchParams.delete('symbol');
+  }
+
+  if (interval) {
+    nextSearchParams.set('interval', interval);
+  } else {
+    nextSearchParams.delete('interval');
+  }
+
+  const query = nextSearchParams.toString();
+  return query ? `/dashboard/charts?${query}` : '/dashboard/charts';
+}
 
 export function ChartPageClient() {
   const searchParams = useSearchParams();
@@ -15,22 +43,52 @@ export function ChartPageClient() {
     useDashboardStore();
 
   const symbol = searchParams.get('symbol');
+  const rawInterval = searchParams.get('interval')?.toLowerCase();
+  const interval = isKLineInterval(rawInterval)
+    ? rawInterval
+    : DEFAULT_KLINE_INTERVAL;
 
   // Sync URL symbol to store
   useEffect(() => {
     if (symbol && symbol !== selectedTicker) {
       setSelectedTicker(symbol);
     } else if (!symbol && selectedTicker) {
-      // If no symbol in URL but there is one in store, update URL
-      router.replace(`/dashboard/charts?symbol=${selectedTicker}`);
+      router.replace(
+        buildChartsHref(
+          new URLSearchParams(searchParams.toString()),
+          selectedTicker,
+          interval
+        )
+      );
     }
-  }, [symbol, selectedTicker, setSelectedTicker, router]);
+  }, [
+    interval,
+    router,
+    searchParams,
+    selectedTicker,
+    setSelectedTicker,
+    symbol
+  ]);
 
   const activeTicker = symbol || selectedTicker;
   const handleTickerSubmit = (ticker: string) => {
-    const nextSearchParams = new URLSearchParams(searchParams.toString());
-    nextSearchParams.set('symbol', ticker);
-    router.replace(`/dashboard/charts?${nextSearchParams.toString()}`);
+    router.replace(
+      buildChartsHref(
+        new URLSearchParams(searchParams.toString()),
+        ticker,
+        interval
+      )
+    );
+  };
+
+  const handleIntervalChange = (nextInterval: KLineInterval) => {
+    router.replace(
+      buildChartsHref(
+        new URLSearchParams(searchParams.toString()),
+        activeTicker,
+        nextInterval
+      )
+    );
   };
 
   return (
@@ -50,6 +108,8 @@ export function ChartPageClient() {
           <KLineChart
             ticker={activeTicker}
             provider={quoteProvider}
+            interval={interval}
+            onIntervalChange={handleIntervalChange}
             className='h-full'
           />
         ) : (

--- a/src/features/stock-dashboard/components/ChartPageClient.tsx
+++ b/src/features/stock-dashboard/components/ChartPageClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { QuoteProviderToggle } from './QuoteProviderToggle';
 import { useDashboardStore } from '../store';
@@ -47,28 +47,31 @@ export function ChartPageClient() {
   const interval = isKLineInterval(rawInterval)
     ? rawInterval
     : DEFAULT_KLINE_INTERVAL;
+  const intervalRef = useRef(interval);
 
-  // Sync URL symbol to store
+  intervalRef.current = interval;
+
   useEffect(() => {
-    if (symbol && symbol !== selectedTicker) {
-      setSelectedTicker(symbol);
-    } else if (!symbol && selectedTicker) {
-      router.replace(
-        buildChartsHref(
-          new URLSearchParams(searchParams.toString()),
-          selectedTicker,
-          interval
-        )
-      );
+    if (!symbol || symbol === selectedTicker) {
+      return;
     }
-  }, [
-    interval,
-    router,
-    searchParams,
-    selectedTicker,
-    setSelectedTicker,
-    symbol
-  ]);
+
+    setSelectedTicker(symbol);
+  }, [selectedTicker, setSelectedTicker, symbol]);
+
+  useEffect(() => {
+    if (symbol || !selectedTicker) {
+      return;
+    }
+
+    router.replace(
+      buildChartsHref(
+        new URLSearchParams(),
+        selectedTicker,
+        intervalRef.current
+      )
+    );
+  }, [router, selectedTicker, symbol]);
 
   const activeTicker = symbol || selectedTicker;
   const handleTickerSubmit = (ticker: string) => {

--- a/src/features/stock-dashboard/components/KLineChart.tsx
+++ b/src/features/stock-dashboard/components/KLineChart.tsx
@@ -7,9 +7,15 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { CANONICAL_QUOTE_PROVIDER } from '@/lib/providers/config';
 import { validateTicker } from '@/lib/validation/ticker';
-import type { TimeRange } from '@/lib/types/stock-api';
+import {
+  DEFAULT_KLINE_INTERVAL,
+  isKLineInterval,
+  type KLineInterval,
+  type TimeRange
+} from '@/lib/types/stock-api';
 import { useKlineSeries } from '../hooks/useKlineSeries';
 import { createKLineChart, type KLineChartHandle } from '../lib/klinecharts';
 
@@ -17,31 +23,54 @@ interface KLineChartProps {
   ticker: string;
   className?: string;
   provider?: string;
+  interval?: KLineInterval;
+  onIntervalChange?: (interval: KLineInterval) => void;
 }
 
-function formatRangeLabel(range?: TimeRange) {
-  if (!range) return '1Y · Daily';
+const KLINE_INTERVAL_OPTIONS: Array<{
+  value: KLineInterval;
+  label: string;
+  badge: string;
+  subtitle: string;
+}> = [
+  { value: 'day', label: 'Day', badge: '1D', subtitle: 'Daily candles' },
+  { value: 'week', label: 'Week', badge: '1W', subtitle: 'Weekly candles' },
+  { value: 'month', label: 'Month', badge: '1M', subtitle: 'Monthly candles' },
+  { value: 'year', label: 'Year', badge: '1Y', subtitle: 'Yearly candles' }
+];
+
+function getIntervalMeta(interval: KLineInterval) {
+  return KLINE_INTERVAL_OPTIONS.find((option) => option.value === interval)!;
+}
+
+function formatRangeLabel(range: TimeRange, fallbackInterval: KLineInterval) {
+  const activeInterval = range.interval ?? fallbackInterval;
   const start = new Date(range.startDate).toLocaleDateString('en', {
     month: 'short',
+    day: 'numeric',
     year: 'numeric'
   });
   const end = new Date(range.endDate).toLocaleDateString('en', {
     month: 'short',
+    day: 'numeric',
     year: 'numeric'
   });
-  return `${start} - ${end} · 1D`;
+  return `${start} - ${end} · ${getIntervalMeta(activeInterval).badge}`;
 }
 
 export function KLineChart({
   ticker,
   className,
-  provider = CANONICAL_QUOTE_PROVIDER
+  provider = CANONICAL_QUOTE_PROVIDER,
+  interval = DEFAULT_KLINE_INTERVAL,
+  onIntervalChange
 }: KLineChartProps) {
   const validation = useMemo(() => validateTicker(ticker), [ticker]);
   const querySymbol = validation.isValid ? ticker : undefined;
   const { data, isLoading, isError, error, noData, refetch } = useKlineSeries(
     querySymbol,
-    provider
+    provider,
+    interval
   );
 
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -69,9 +98,14 @@ export function KLineChart({
   );
 
   const rangeLabel = useMemo(
-    () => formatRangeLabel(data?.range),
-    [data?.range]
+    () =>
+      data?.range
+        ? formatRangeLabel(data.range, interval)
+        : getIntervalMeta(interval).badge,
+    [data?.range, interval]
   );
+  const selectedInterval = data?.range.interval ?? interval;
+  const intervalMeta = getIntervalMeta(selectedInterval);
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -90,6 +124,7 @@ export function KLineChart({
 
     createKLineChart(containerRef.current, {
       symbol: ticker,
+      interval,
       data: []
     })
       .then((handle) => {
@@ -123,8 +158,8 @@ export function KLineChart({
 
   useEffect(() => {
     if (!chartRef.current || !querySymbol) return;
-    chartRef.current.update(querySymbol, chartData);
-  }, [chartData, querySymbol]);
+    chartRef.current.update(querySymbol, chartData, interval);
+  }, [chartData, chartReady, interval, querySymbol]);
 
   const handleRetry = () => {
     if (chartError) {
@@ -171,17 +206,42 @@ export function KLineChart({
 
   return (
     <Card className={`overflow-hidden ${className}`}>
-      <CardHeader className='pb-3'>
-        <div className='flex items-start justify-between gap-3'>
+      <CardHeader className='space-y-3 pb-3'>
+        <div className='flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between'>
           <div className='space-y-1'>
             <CardTitle className='text-xl font-semibold'>
               {ticker} K Line Chart
             </CardTitle>
             <div className='text-muted-foreground text-xs'>
-              1-year daily candles
+              {intervalMeta.subtitle}
             </div>
           </div>
-          <Badge variant='outline'>{rangeLabel}</Badge>
+          <div className='flex flex-col items-start gap-3 sm:flex-row sm:items-center lg:flex-col lg:items-end'>
+            <Badge variant='outline'>{rangeLabel}</Badge>
+            <ToggleGroup
+              type='single'
+              value={interval}
+              variant='outline'
+              size='sm'
+              aria-label='K line interval'
+              className='w-full flex-wrap sm:w-auto'
+              onValueChange={(value) => {
+                if (isKLineInterval(value) && value !== interval) {
+                  onIntervalChange?.(value);
+                }
+              }}
+            >
+              {KLINE_INTERVAL_OPTIONS.map((option) => (
+                <ToggleGroupItem
+                  key={option.value}
+                  value={option.value}
+                  aria-label={`${option.label} interval`}
+                >
+                  {option.label}
+                </ToggleGroupItem>
+              ))}
+            </ToggleGroup>
+          </div>
         </div>
       </CardHeader>
       <CardContent className='p-0'>

--- a/src/features/stock-dashboard/components/KLineChart.tsx
+++ b/src/features/stock-dashboard/components/KLineChart.tsx
@@ -27,24 +27,33 @@ interface KLineChartProps {
   onIntervalChange?: (interval: KLineInterval) => void;
 }
 
+const KLINE_INTERVAL_META: Record<
+  KLineInterval,
+  {
+    badge: string;
+    label: string;
+    subtitle: string;
+  }
+> = {
+  day: { label: 'Day', badge: '1D', subtitle: 'Daily candles' },
+  week: { label: 'Week', badge: '1W', subtitle: 'Weekly candles' },
+  month: { label: 'Month', badge: '1M', subtitle: 'Monthly candles' },
+  year: { label: 'Year', badge: '1Y', subtitle: 'Yearly candles' }
+};
+
 const KLINE_INTERVAL_OPTIONS: Array<{
-  value: KLineInterval;
   label: string;
-  badge: string;
-  subtitle: string;
-}> = [
-  { value: 'day', label: 'Day', badge: '1D', subtitle: 'Daily candles' },
-  { value: 'week', label: 'Week', badge: '1W', subtitle: 'Weekly candles' },
-  { value: 'month', label: 'Month', badge: '1M', subtitle: 'Monthly candles' },
-  { value: 'year', label: 'Year', badge: '1Y', subtitle: 'Yearly candles' }
-];
+  value: KLineInterval;
+}> = (['day', 'week', 'month', 'year'] as const).map((value) => ({
+  value,
+  label: KLINE_INTERVAL_META[value].label
+}));
 
 function getIntervalMeta(interval: KLineInterval) {
-  return KLINE_INTERVAL_OPTIONS.find((option) => option.value === interval)!;
+  return KLINE_INTERVAL_META[interval];
 }
 
-function formatRangeLabel(range: TimeRange, fallbackInterval: KLineInterval) {
-  const activeInterval = range.interval ?? fallbackInterval;
+function formatRangeLabel(range: TimeRange) {
   const start = new Date(range.startDate).toLocaleDateString('en', {
     month: 'short',
     day: 'numeric',
@@ -55,7 +64,7 @@ function formatRangeLabel(range: TimeRange, fallbackInterval: KLineInterval) {
     day: 'numeric',
     year: 'numeric'
   });
-  return `${start} - ${end} · ${getIntervalMeta(activeInterval).badge}`;
+  return `${start} - ${end} · ${getIntervalMeta(range.interval).badge}`;
 }
 
 export function KLineChart({
@@ -69,8 +78,8 @@ export function KLineChart({
   const querySymbol = validation.isValid ? ticker : undefined;
   const { data, isLoading, isError, error, noData, refetch } = useKlineSeries(
     querySymbol,
-    provider,
-    interval
+    interval,
+    provider
   );
 
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -100,7 +109,7 @@ export function KLineChart({
   const rangeLabel = useMemo(
     () =>
       data?.range
-        ? formatRangeLabel(data.range, interval)
+        ? formatRangeLabel(data.range)
         : getIntervalMeta(interval).badge,
     [data?.range, interval]
   );

--- a/src/features/stock-dashboard/components/__tests__/KLineChart.test.tsx
+++ b/src/features/stock-dashboard/components/__tests__/KLineChart.test.tsx
@@ -6,6 +6,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { KLineChart } from '../KLineChart';
 import { useKlineSeries } from '../../hooks/useKlineSeries';
+import type { KLineInterval } from '@/lib/types/stock-api';
 
 jest.mock('../../hooks/useKlineSeries');
 jest.mock('../../lib/klinecharts', () => ({
@@ -20,6 +21,17 @@ const mockUseKlineSeries = useKlineSeries as jest.MockedFunction<
 >;
 
 describe('KLineChart', () => {
+  const buildSeries = (interval: KLineInterval = 'day') => ({
+    symbol: 'AAPL',
+    range: {
+      startDate: '2023-01-01T00:00:00.000Z',
+      endDate: '2024-01-01T00:00:00.000Z',
+      interval
+    },
+    candles: [],
+    lastUpdated: '2024-01-01T00:00:00.000Z'
+  });
+
   beforeEach(() => {
     mockUseKlineSeries.mockReset();
   });
@@ -43,7 +55,7 @@ describe('KLineChart', () => {
 
   it('updates ticker label when ticker changes', () => {
     mockUseKlineSeries.mockReturnValue({
-      data: null,
+      data: buildSeries(),
       isLoading: false,
       isError: false,
       error: null,
@@ -60,16 +72,7 @@ describe('KLineChart', () => {
 
   it('renders no-data state with retry action', () => {
     mockUseKlineSeries.mockReturnValue({
-      data: {
-        symbol: 'AAPL',
-        range: {
-          startDate: '2023-01-01T00:00:00.000Z',
-          endDate: '2024-01-01T00:00:00.000Z',
-          interval: '1d'
-        },
-        candles: [],
-        lastUpdated: '2024-01-01T00:00:00.000Z'
-      },
+      data: buildSeries(),
       isLoading: false,
       isError: false,
       error: null,
@@ -83,6 +86,37 @@ describe('KLineChart', () => {
       screen.getByText('No K line data available for AAPL.')
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+
+  it('renders the interval selector and active interval metadata', async () => {
+    mockUseKlineSeries.mockReturnValue({
+      data: buildSeries('month'),
+      isLoading: false,
+      isError: false,
+      error: null,
+      noData: false,
+      refetch: jest.fn()
+    } as any);
+
+    const onIntervalChange = jest.fn();
+
+    render(
+      <KLineChart
+        ticker='AAPL'
+        interval='month'
+        onIntervalChange={onIntervalChange}
+      />
+    );
+
+    expect(screen.getByText('Monthly candles')).toBeInTheDocument();
+    expect(screen.getByText(/1M/)).toBeInTheDocument();
+    expect(
+      screen.getByRole('radio', { name: 'Month interval' })
+    ).toHaveAttribute('data-state', 'on');
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Week interval' }));
+
+    expect(onIntervalChange).toHaveBeenCalledWith('week');
   });
 
   it('renders error state and calls retry', async () => {

--- a/src/features/stock-dashboard/components/__tests__/chart-page-client.test.tsx
+++ b/src/features/stock-dashboard/components/__tests__/chart-page-client.test.tsx
@@ -108,6 +108,27 @@ describe('ChartPageClient', () => {
     expect(screen.getByTestId('kline-chart')).toHaveTextContent('AAPL:day');
   });
 
+  test('hydrates the missing symbol in the URL from the store without dropping the interval', () => {
+    const replace = jest.fn();
+
+    (useRouter as jest.Mock).mockReturnValue({ replace });
+    (useSearchParams as jest.Mock).mockReturnValue({
+      get: (key: string) => (key === 'interval' ? 'month' : null),
+      toString: () => 'interval=month'
+    });
+    (useDashboardStore as unknown as jest.Mock).mockReturnValue({
+      selectedTicker: 'NVDA',
+      setSelectedTicker: jest.fn(),
+      quoteProvider: 'default'
+    });
+
+    render(<ChartPageClient />);
+
+    expect(replace).toHaveBeenCalledWith(
+      '/dashboard/charts?symbol=NVDA&interval=month'
+    );
+  });
+
   test('preserves the symbol when the chart interval changes', () => {
     const replace = jest.fn();
 

--- a/src/features/stock-dashboard/components/__tests__/chart-page-client.test.tsx
+++ b/src/features/stock-dashboard/components/__tests__/chart-page-client.test.tsx
@@ -21,8 +21,21 @@ jest.mock('../QuoteProviderToggle', () => ({
 }));
 
 jest.mock('../KLineChart', () => ({
-  KLineChart: ({ ticker }: { ticker: string }) => (
-    <div data-testid='kline-chart'>{ticker}</div>
+  KLineChart: ({
+    ticker,
+    interval,
+    onIntervalChange
+  }: {
+    ticker: string;
+    interval: string;
+    onIntervalChange?: (interval: 'day' | 'week' | 'month' | 'year') => void;
+  }) => (
+    <div>
+      <div data-testid='kline-chart'>{`${ticker}:${interval}`}</div>
+      <button type='button' onClick={() => onIntervalChange?.('year')}>
+        Switch Interval
+      </button>
+    </div>
   )
 }));
 
@@ -31,14 +44,15 @@ describe('ChartPageClient', () => {
     jest.resetAllMocks();
   });
 
-  test('replaces the symbol query param when searching from the charts page', () => {
+  test('replaces the symbol query param when searching from the charts page and preserves the interval', () => {
     const replace = jest.fn();
     const setSelectedTicker = jest.fn();
 
     (useRouter as jest.Mock).mockReturnValue({ replace });
     (useSearchParams as jest.Mock).mockReturnValue({
-      get: (key: string) => (key === 'symbol' ? 'GOOGL' : null),
-      toString: () => 'symbol=GOOGL'
+      get: (key: string) =>
+        key === 'symbol' ? 'GOOGL' : key === 'interval' ? 'week' : null,
+      toString: () => 'symbol=GOOGL&interval=week'
     });
     (useDashboardStore as unknown as jest.Mock).mockReturnValue({
       selectedTicker: 'GOOGL',
@@ -53,7 +67,67 @@ describe('ChartPageClient', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: 'Search' }));
 
-    expect(replace).toHaveBeenCalledWith('/dashboard/charts?symbol=AAPL');
+    expect(replace).toHaveBeenCalledWith(
+      '/dashboard/charts?symbol=AAPL&interval=week'
+    );
     expect(setSelectedTicker).not.toHaveBeenCalled();
+  });
+
+  test('passes the selected interval from the URL into the chart', () => {
+    (useRouter as jest.Mock).mockReturnValue({ replace: jest.fn() });
+    (useSearchParams as jest.Mock).mockReturnValue({
+      get: (key: string) =>
+        key === 'symbol' ? 'GOOGL' : key === 'interval' ? 'month' : null,
+      toString: () => 'symbol=GOOGL&interval=month'
+    });
+    (useDashboardStore as unknown as jest.Mock).mockReturnValue({
+      selectedTicker: 'GOOGL',
+      setSelectedTicker: jest.fn(),
+      quoteProvider: 'default'
+    });
+
+    render(<ChartPageClient />);
+
+    expect(screen.getByTestId('kline-chart')).toHaveTextContent('GOOGL:month');
+  });
+
+  test('defaults the chart interval to day when the URL omits it', () => {
+    (useRouter as jest.Mock).mockReturnValue({ replace: jest.fn() });
+    (useSearchParams as jest.Mock).mockReturnValue({
+      get: (key: string) => (key === 'symbol' ? 'AAPL' : null),
+      toString: () => 'symbol=AAPL'
+    });
+    (useDashboardStore as unknown as jest.Mock).mockReturnValue({
+      selectedTicker: 'AAPL',
+      setSelectedTicker: jest.fn(),
+      quoteProvider: 'default'
+    });
+
+    render(<ChartPageClient />);
+
+    expect(screen.getByTestId('kline-chart')).toHaveTextContent('AAPL:day');
+  });
+
+  test('preserves the symbol when the chart interval changes', () => {
+    const replace = jest.fn();
+
+    (useRouter as jest.Mock).mockReturnValue({ replace });
+    (useSearchParams as jest.Mock).mockReturnValue({
+      get: (key: string) =>
+        key === 'symbol' ? 'MSFT' : key === 'interval' ? 'week' : null,
+      toString: () => 'symbol=MSFT&interval=week'
+    });
+    (useDashboardStore as unknown as jest.Mock).mockReturnValue({
+      selectedTicker: 'MSFT',
+      setSelectedTicker: jest.fn(),
+      quoteProvider: 'default'
+    });
+
+    render(<ChartPageClient />);
+    fireEvent.click(screen.getByRole('button', { name: 'Switch Interval' }));
+
+    expect(replace).toHaveBeenCalledWith(
+      '/dashboard/charts?symbol=MSFT&interval=year'
+    );
   });
 });

--- a/src/features/stock-dashboard/hooks/__tests__/useKlineSeries.test.tsx
+++ b/src/features/stock-dashboard/hooks/__tests__/useKlineSeries.test.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import { useKlineSeries } from '../useKlineSeries';
 import { CANONICAL_QUOTE_PROVIDER } from '@/lib/providers/config';
+import type { KLineInterval } from '@/lib/types/stock-api';
 
 jest.mock('@sentry/nextjs', () => ({
   startSpan: jest.fn((_context: unknown, callback: any) =>
@@ -16,12 +17,18 @@ jest.mock('@sentry/nextjs', () => ({
 
 function TestHarness({
   symbol,
-  provider = CANONICAL_QUOTE_PROVIDER
+  provider = CANONICAL_QUOTE_PROVIDER,
+  interval = 'day'
 }: {
   symbol?: string;
   provider?: string;
+  interval?: KLineInterval;
 }) {
-  const { data, isLoading, noData } = useKlineSeries(symbol, provider);
+  const { data, isLoading, noData } = useKlineSeries(
+    symbol,
+    provider,
+    interval
+  );
 
   return (
     <div>
@@ -60,6 +67,7 @@ describe('useKlineSeries', () => {
 
       expect(url.pathname).toBe('/api/stocks/kline/AAPL');
       expect(url.searchParams.get('provider')).toBe(CANONICAL_QUOTE_PROVIDER);
+      expect(url.searchParams.get('interval')).toBe('day');
 
       return {
         ok: true,
@@ -70,7 +78,7 @@ describe('useKlineSeries', () => {
             range: {
               startDate: '2023-01-01T00:00:00.000Z',
               endDate: '2024-01-01T00:00:00.000Z',
-              interval: '1d'
+              interval: 'day'
             },
             candles: [
               {
@@ -106,21 +114,21 @@ describe('useKlineSeries', () => {
     expect(screen.getByTestId('loading')).toHaveTextContent('true');
   });
 
-  it('refetches when the provider changes', async () => {
+  it('refetches when the interval changes', async () => {
     global.fetch = jest.fn(async (input: RequestInfo | URL) => {
       const url = new URL(String(input), 'http://localhost:3000');
-      const provider = url.searchParams.get('provider') || '';
+      const interval = url.searchParams.get('interval') || '';
 
       return {
         ok: true,
         json: async () => ({
           success: true,
           data: {
-            symbol: provider,
+            symbol: interval,
             range: {
               startDate: '2023-01-01T00:00:00.000Z',
               endDate: '2024-01-01T00:00:00.000Z',
-              interval: '1d'
+              interval: interval as KLineInterval
             },
             candles: [],
             lastUpdated: '2024-01-01T00:00:00.000Z'
@@ -130,13 +138,11 @@ describe('useKlineSeries', () => {
     }) as any;
 
     const { rerender } = renderWithClient(
-      <TestHarness symbol='AAPL' provider={CANONICAL_QUOTE_PROVIDER} />
+      <TestHarness symbol='AAPL' interval='day' />
     );
 
     await waitFor(() =>
-      expect(screen.getByTestId('symbol')).toHaveTextContent(
-        CANONICAL_QUOTE_PROVIDER
-      )
+      expect(screen.getByTestId('symbol')).toHaveTextContent('day')
     );
 
     rerender(
@@ -147,12 +153,12 @@ describe('useKlineSeries', () => {
           })
         }
       >
-        <TestHarness symbol='AAPL' provider='default' />
+        <TestHarness symbol='AAPL' interval='week' />
       </QueryClientProvider>
     );
 
     await waitFor(() =>
-      expect(screen.getByTestId('symbol')).toHaveTextContent('default')
+      expect(screen.getByTestId('symbol')).toHaveTextContent('week')
     );
   });
 });

--- a/src/features/stock-dashboard/hooks/__tests__/useKlineSeries.test.tsx
+++ b/src/features/stock-dashboard/hooks/__tests__/useKlineSeries.test.tsx
@@ -17,17 +17,17 @@ jest.mock('@sentry/nextjs', () => ({
 
 function TestHarness({
   symbol,
-  provider = CANONICAL_QUOTE_PROVIDER,
-  interval = 'day'
+  interval = 'day',
+  provider = CANONICAL_QUOTE_PROVIDER
 }: {
   symbol?: string;
-  provider?: string;
   interval?: KLineInterval;
+  provider?: string;
 }) {
   const { data, isLoading, noData } = useKlineSeries(
     symbol,
-    provider,
-    interval
+    interval,
+    provider
   );
 
   return (
@@ -159,6 +159,56 @@ describe('useKlineSeries', () => {
 
     await waitFor(() =>
       expect(screen.getByTestId('symbol')).toHaveTextContent('week')
+    );
+  });
+
+  it('refetches when the provider changes', async () => {
+    global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input), 'http://localhost:3000');
+      const provider = url.searchParams.get('provider') || '';
+
+      return {
+        ok: true,
+        json: async () => ({
+          success: true,
+          data: {
+            symbol: provider,
+            range: {
+              startDate: '2023-01-01T00:00:00.000Z',
+              endDate: '2024-01-01T00:00:00.000Z',
+              interval: 'day'
+            },
+            candles: [],
+            lastUpdated: '2024-01-01T00:00:00.000Z'
+          }
+        })
+      } as any;
+    }) as any;
+
+    const { rerender } = renderWithClient(
+      <TestHarness symbol='AAPL' provider={CANONICAL_QUOTE_PROVIDER} />
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('symbol')).toHaveTextContent(
+        CANONICAL_QUOTE_PROVIDER
+      )
+    );
+
+    rerender(
+      <QueryClientProvider
+        client={
+          new QueryClient({
+            defaultOptions: { queries: { retry: 0 } }
+          })
+        }
+      >
+        <TestHarness symbol='AAPL' provider='default' />
+      </QueryClientProvider>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('symbol')).toHaveTextContent('default')
     );
   });
 });

--- a/src/features/stock-dashboard/hooks/useKlineSeries.ts
+++ b/src/features/stock-dashboard/hooks/useKlineSeries.ts
@@ -2,12 +2,18 @@
 
 import { useQuery } from '@tanstack/react-query';
 import * as Sentry from '@sentry/nextjs';
-import { APIResponse, KLineSeries } from '@/lib/types/stock-api';
+import {
+  APIResponse,
+  DEFAULT_KLINE_INTERVAL,
+  type KLineInterval,
+  KLineSeries
+} from '@/lib/types/stock-api';
 import { CANONICAL_QUOTE_PROVIDER } from '@/lib/providers/config';
 
 async function fetchKlineSeries(
   symbol: string,
-  provider: string = CANONICAL_QUOTE_PROVIDER
+  provider: string = CANONICAL_QUOTE_PROVIDER,
+  interval: KLineInterval = DEFAULT_KLINE_INTERVAL
 ): Promise<KLineSeries> {
   return Sentry.startSpan(
     { op: 'http.client', name: `GET /api/stocks/kline/${symbol}` },
@@ -16,7 +22,7 @@ async function fetchKlineSeries(
       const timeoutId = setTimeout(() => controller.abort(), 10000);
 
       try {
-        const searchParams = new URLSearchParams({ provider });
+        const searchParams = new URLSearchParams({ provider, interval });
         const response = await fetch(
           `/api/stocks/kline/${symbol}?${searchParams.toString()}`,
           {
@@ -55,11 +61,12 @@ async function fetchKlineSeries(
 
 export function useKlineSeries(
   symbol?: string,
-  provider: string = CANONICAL_QUOTE_PROVIDER
+  provider: string = CANONICAL_QUOTE_PROVIDER,
+  interval: KLineInterval = DEFAULT_KLINE_INTERVAL
 ) {
   const query = useQuery({
-    queryKey: ['kline-series', symbol, provider],
-    queryFn: () => fetchKlineSeries(symbol!, provider),
+    queryKey: ['kline-series', symbol, provider, interval],
+    queryFn: () => fetchKlineSeries(symbol!, provider, interval),
     enabled: !!symbol,
     staleTime: 24 * 60 * 60 * 1000,
     refetchInterval: false as const,

--- a/src/features/stock-dashboard/hooks/useKlineSeries.ts
+++ b/src/features/stock-dashboard/hooks/useKlineSeries.ts
@@ -12,8 +12,8 @@ import { CANONICAL_QUOTE_PROVIDER } from '@/lib/providers/config';
 
 async function fetchKlineSeries(
   symbol: string,
-  provider: string = CANONICAL_QUOTE_PROVIDER,
-  interval: KLineInterval = DEFAULT_KLINE_INTERVAL
+  interval: KLineInterval = DEFAULT_KLINE_INTERVAL,
+  provider: string = CANONICAL_QUOTE_PROVIDER
 ): Promise<KLineSeries> {
   return Sentry.startSpan(
     { op: 'http.client', name: `GET /api/stocks/kline/${symbol}` },
@@ -61,12 +61,12 @@ async function fetchKlineSeries(
 
 export function useKlineSeries(
   symbol?: string,
-  provider: string = CANONICAL_QUOTE_PROVIDER,
-  interval: KLineInterval = DEFAULT_KLINE_INTERVAL
+  interval: KLineInterval = DEFAULT_KLINE_INTERVAL,
+  provider: string = CANONICAL_QUOTE_PROVIDER
 ) {
   const query = useQuery({
     queryKey: ['kline-series', symbol, provider, interval],
-    queryFn: () => fetchKlineSeries(symbol!, provider, interval),
+    queryFn: () => fetchKlineSeries(symbol!, interval, provider),
     enabled: !!symbol,
     staleTime: 24 * 60 * 60 * 1000,
     refetchInterval: false as const,

--- a/src/features/stock-dashboard/lib/klinecharts.ts
+++ b/src/features/stock-dashboard/lib/klinecharts.ts
@@ -1,12 +1,14 @@
 import type { Chart, KLineData } from 'klinecharts';
+import type { KLineInterval } from '@/lib/types/stock-api';
 
 export interface KLineChartHandle {
-  update: (symbol: string, data: KLineData[]) => void;
+  update: (symbol: string, data: KLineData[], interval: KLineInterval) => void;
   destroy: () => void;
 }
 
 export interface CreateKLineChartOptions {
   symbol: string;
+  interval: KLineInterval;
   data?: KLineData[];
 }
 
@@ -19,13 +21,18 @@ async function getKLineModule() {
   return klineModule;
 }
 
-function applyData(chart: Chart, symbol: string, data: KLineData[]) {
+function applyData(
+  chart: Chart,
+  symbol: string,
+  data: KLineData[],
+  interval: KLineInterval
+) {
   chart.setSymbol({
     ticker: symbol,
     pricePrecision: 2,
     volumePrecision: 0
   });
-  chart.setPeriod({ type: 'day', span: 1 });
+  chart.setPeriod({ type: interval, span: 1 });
   chart.setDataLoader({
     getBars: ({ callback }) => {
       callback(data, false);
@@ -45,7 +52,7 @@ export async function createKLineChart(
     throw new Error('Failed to initialize kline chart');
   }
 
-  applyData(chart, options.symbol, options.data ?? []);
+  applyData(chart, options.symbol, options.data ?? [], options.interval);
 
   const resizeObserver = new ResizeObserver(() => {
     chart.resize();
@@ -54,7 +61,8 @@ export async function createKLineChart(
   resizeObserver.observe(container);
 
   return {
-    update: (symbol, data) => applyData(chart, symbol, data),
+    update: (symbol, data, interval) =>
+      applyData(chart, symbol, data, interval),
     destroy: () => {
       resizeObserver.disconnect();
       dispose(chart);

--- a/src/lib/providers/__tests__/longbridge.test.ts
+++ b/src/lib/providers/__tests__/longbridge.test.ts
@@ -1,0 +1,91 @@
+import { LongbridgeProvider } from '../longbridge';
+
+const mockCandlesticks = jest.fn();
+const mockQuoteContextNew = jest.fn();
+
+jest.mock('longport', () => ({
+  Config: {
+    fromEnv: jest.fn(() => ({}))
+  },
+  QuoteContext: {
+    new: (...args: unknown[]) => mockQuoteContextNew(...args)
+  },
+  AdjustType: {},
+  Period: {},
+  TradeSessions: {}
+}));
+
+jest.mock('../../logger', () => ({
+  logger: {
+    error: jest.fn()
+  }
+}));
+
+describe('LongbridgeProvider.getKLines', () => {
+  const originalEnv = {
+    LONGPORT_APP_KEY: process.env.LONGPORT_APP_KEY,
+    LONGPORT_APP_SECRET: process.env.LONGPORT_APP_SECRET,
+    LONGPORT_ACCESS_TOKEN: process.env.LONGPORT_ACCESS_TOKEN
+  };
+
+  beforeEach(() => {
+    process.env.LONGPORT_APP_KEY = 'app-key';
+    process.env.LONGPORT_APP_SECRET = 'app-secret';
+    process.env.LONGPORT_ACCESS_TOKEN = 'token';
+
+    mockCandlesticks.mockReset();
+    mockQuoteContextNew.mockReset();
+    mockQuoteContextNew.mockResolvedValue({
+      candlesticks: mockCandlesticks
+    });
+  });
+
+  afterAll(() => {
+    process.env.LONGPORT_APP_KEY = originalEnv.LONGPORT_APP_KEY;
+    process.env.LONGPORT_APP_SECRET = originalEnv.LONGPORT_APP_SECRET;
+    process.env.LONGPORT_ACCESS_TOKEN = originalEnv.LONGPORT_ACCESS_TOKEN;
+  });
+
+  it.each([
+    ['day', 14],
+    ['week', 15],
+    ['month', 16],
+    ['year', 18]
+  ] as const)(
+    'maps the %s interval to Longbridge period %i',
+    async (interval, expectedPeriod) => {
+      mockCandlesticks.mockResolvedValue([
+        {
+          timestamp: new Date('2024-01-02T00:00:00.000Z'),
+          open: 100,
+          high: 110,
+          low: 95,
+          close: 105,
+          volume: 1000
+        }
+      ]);
+
+      const provider = new LongbridgeProvider();
+      const series = await provider.getKLines('AAPL', interval);
+
+      expect(mockCandlesticks).toHaveBeenCalledWith(
+        'AAPL.US',
+        expectedPeriod,
+        1000,
+        1,
+        1
+      );
+      expect(series.range.interval).toBe(interval);
+      expect(series.symbol).toBe('AAPL');
+    }
+  );
+
+  it('defaults to the day interval when none is provided', async () => {
+    mockCandlesticks.mockResolvedValue([]);
+
+    const provider = new LongbridgeProvider();
+    await provider.getKLines('AAPL');
+
+    expect(mockCandlesticks).toHaveBeenCalledWith('AAPL.US', 14, 1000, 1, 1);
+  });
+});

--- a/src/lib/providers/longbridge.ts
+++ b/src/lib/providers/longbridge.ts
@@ -1,6 +1,8 @@
 import {
   StockQuote,
   APIError,
+  DEFAULT_KLINE_INTERVAL,
+  type KLineInterval,
   KLineSeries,
   KLineCandle,
   TimeRange
@@ -15,6 +17,15 @@ import {
   AdjustType,
   TradeSessions
 } from 'longport';
+
+const LONG_BRIDGE_KLINE_COUNT = 1000;
+
+const LONG_BRIDGE_PERIOD_MAP: Record<KLineInterval, number> = {
+  day: 14,
+  week: 15,
+  month: 16,
+  year: 18
+};
 
 export class LongbridgeProvider implements StockDataProvider {
   name = 'Longbridge';
@@ -92,7 +103,10 @@ export class LongbridgeProvider implements StockDataProvider {
     }
   }
 
-  async getKLines(symbol: string): Promise<KLineSeries> {
+  async getKLines(
+    symbol: string,
+    interval: KLineInterval = DEFAULT_KLINE_INTERVAL
+  ): Promise<KLineSeries> {
     if (
       !process.env.LONGPORT_APP_KEY ||
       !process.env.LONGPORT_APP_SECRET ||
@@ -110,19 +124,19 @@ export class LongbridgeProvider implements StockDataProvider {
 
       const longbridgeSymbol = this.normalizeSymbol(symbol);
 
-      // Fetch daily candles using numeric values to avoid isolatedModules const enum issues
-      // Period.Day = 14
+      // Fetch candles using numeric values to avoid isolatedModules const enum issues.
+      const period = LONG_BRIDGE_PERIOD_MAP[interval];
       // AdjustType.ForwardAdjust = 1
       // TradeSessions.All = 1
       const candlesData = await context.candlesticks(
         longbridgeSymbol,
-        14 as unknown as Period,
-        1000,
+        period as unknown as Period,
+        LONG_BRIDGE_KLINE_COUNT,
         1 as unknown as AdjustType,
         1 as unknown as TradeSessions
       );
 
-      return this.transformCandlesticksToSeries(candlesData, symbol);
+      return this.transformCandlesticksToSeries(candlesData, symbol, interval);
     } catch (error) {
       logger.error('Longbridge KLine Error', { error });
 
@@ -145,7 +159,8 @@ export class LongbridgeProvider implements StockDataProvider {
 
   private transformCandlesticksToSeries(
     candlesData: Candlestick[],
-    symbol: string
+    symbol: string,
+    interval: KLineInterval
   ): KLineSeries {
     // Longbridge Candlestick: { close, high, low, open, timestamp, volume, ... }
     // Timestamp is a Date; convert to milliseconds for JS Date usage.
@@ -172,7 +187,7 @@ export class LongbridgeProvider implements StockDataProvider {
     const range: TimeRange = {
       startDate,
       endDate,
-      interval: '1d'
+      interval
     };
 
     return {

--- a/src/lib/providers/longbridge.ts
+++ b/src/lib/providers/longbridge.ts
@@ -20,6 +20,7 @@ import {
 
 const LONG_BRIDGE_KLINE_COUNT = 1000;
 
+// Longbridge exposes const-enum Period values where 17 is Quarter and 18 is Year.
 const LONG_BRIDGE_PERIOD_MAP: Record<KLineInterval, number> = {
   day: 14,
   week: 15,

--- a/src/lib/providers/types.ts
+++ b/src/lib/providers/types.ts
@@ -1,7 +1,11 @@
-import { StockQuote, KLineSeries } from '../types/stock-api';
+import {
+  type KLineInterval,
+  KLineSeries,
+  StockQuote
+} from '../types/stock-api';
 
 export interface StockDataProvider {
   name: string;
   getQuote(symbol: string): Promise<StockQuote>;
-  getKLines(symbol: string): Promise<KLineSeries>;
+  getKLines(symbol: string, interval?: KLineInterval): Promise<KLineSeries>;
 }

--- a/src/lib/services/__tests__/stock-service.test.ts
+++ b/src/lib/services/__tests__/stock-service.test.ts
@@ -40,7 +40,7 @@ const mockSeries: KLineSeries = {
   range: {
     startDate: '2023-01-01T00:00:00.000Z',
     endDate: '2024-01-01T00:00:00.000Z',
-    interval: '1d'
+    interval: 'day'
   },
   candles: [
     {
@@ -91,9 +91,9 @@ describe('StockService', () => {
       };
       provider.getQuote.mockRejectedValue(apiError);
 
-      await expect(stockService.getQuote('AAPL', 'legacy-provider')).rejects.toBe(
-        apiError
-      );
+      await expect(
+        stockService.getQuote('AAPL', 'legacy-provider')
+      ).rejects.toBe(apiError);
     });
 
     it('wraps unknown provider failures', async () => {
@@ -112,11 +112,24 @@ describe('StockService', () => {
     it('returns series data from the configured provider', async () => {
       provider.getKLines.mockResolvedValue(mockSeries);
 
-      const result = await stockService.getKLineSeries('AAPL', 'default');
+      const result = await stockService.getKLineSeries(
+        'AAPL',
+        'week',
+        'default'
+      );
 
       expect(mockGetProvider).toHaveBeenCalledWith('default');
-      expect(provider.getKLines).toHaveBeenCalledWith('AAPL');
+      expect(provider.getKLines).toHaveBeenCalledWith('AAPL', 'week');
       expect(result).toEqual(mockSeries);
+    });
+
+    it('defaults to the day interval when none is provided', async () => {
+      provider.getKLines.mockResolvedValue(mockSeries);
+
+      await stockService.getKLineSeries('AAPL');
+
+      expect(provider.getKLines).toHaveBeenCalledWith('AAPL', 'day');
+      expect(mockGetProvider).toHaveBeenCalledWith(CANONICAL_QUOTE_PROVIDER);
     });
 
     it('wraps unexpected kline errors', async () => {

--- a/src/lib/services/api-errors.ts
+++ b/src/lib/services/api-errors.ts
@@ -46,6 +46,7 @@ export function createSuccessResponse<T>(
 export function getStatusCodeForError(code: APIErrorCode): number {
   const statusMap: Record<APIErrorCode, number> = {
     INVALID_SYMBOL: 400,
+    INVALID_INTERVAL: 400,
     INVALID_PROVIDER: 400,
     API_LIMIT_EXCEEDED: 429,
     INVALID_API_KEY: 401,

--- a/src/lib/services/stock-service.ts
+++ b/src/lib/services/stock-service.ts
@@ -1,6 +1,12 @@
 import { CANONICAL_QUOTE_PROVIDER } from '../providers/config';
 import { StockProviderFactory } from '../providers/factory';
-import { APIError, KLineSeries, StockQuote } from '../types/stock-api';
+import {
+  APIError,
+  DEFAULT_KLINE_INTERVAL,
+  type KLineInterval,
+  KLineSeries,
+  StockQuote
+} from '../types/stock-api';
 
 export class StockService {
   async getMultipleQuotes(
@@ -68,11 +74,12 @@ export class StockService {
 
   async getKLineSeries(
     symbol: string,
+    interval: KLineInterval = DEFAULT_KLINE_INTERVAL,
     provider: string = CANONICAL_QUOTE_PROVIDER
   ): Promise<KLineSeries> {
     try {
       const stockProvider = StockProviderFactory.getProvider(provider);
-      return await stockProvider.getKLines(symbol);
+      return await stockProvider.getKLines(symbol, interval);
     } catch (error) {
       if (this.isAPIError(error)) {
         throw error;

--- a/src/lib/types/stock-api.ts
+++ b/src/lib/types/stock-api.ts
@@ -34,10 +34,22 @@ export interface KLineCandle {
   volume: number;
 }
 
+export const KLINE_INTERVALS = ['day', 'week', 'month', 'year'] as const;
+
+export type KLineInterval = (typeof KLINE_INTERVALS)[number];
+
+export const DEFAULT_KLINE_INTERVAL: KLineInterval = 'day';
+
+export function isKLineInterval(
+  value: string | null | undefined
+): value is KLineInterval {
+  return KLINE_INTERVALS.includes(value as KLineInterval);
+}
+
 export interface TimeRange {
   startDate: string;
   endDate: string;
-  interval: '1d';
+  interval: KLineInterval;
 }
 
 export interface KLineSeries {
@@ -73,6 +85,7 @@ export interface StockNewsItem {
 
 export type APIErrorCode =
   | 'INVALID_SYMBOL'
+  | 'INVALID_INTERVAL'
   | 'INVALID_PROVIDER'
   | 'API_LIMIT_EXCEEDED'
   | 'NETWORK_ERROR'

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -32,7 +32,11 @@ process.env.NODE_ENV = 'test';
 
 Object.assign(global, {
   TextEncoder,
-  TextDecoder
+  TextDecoder,
+  Request: globalThis.Request,
+  Response: globalThis.Response,
+  Headers: globalThis.Headers,
+  fetch: globalThis.fetch
 });
 
 // Global test utilities and mocks can be added here


### PR DESCRIPTION
Summary
- add the Day/Week/Month/Year selector to the chart header, keep the range badge tied to the active interval, and drop the 3-day option
- thread a typed `interval` through the page’s query params, hook, API route, service, and provider so every layer defaults to `day` and rejects invalid values
- keep existing tests but expand coverage for interval propagation, URL syncing, and Longbridge mapping while noting the API error change

Testing
- Not run (not requested)