### PR TITLE
Add in-app setup diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
+    "dev": "^0.1.3",
     "eslint": "8.48.0",
     "eslint-config-next": "15.1.0",
     "input-otp": "^1.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      dev:
+        specifier: ^0.1.3
+        version: 0.1.3
       eslint:
         specifier: 8.48.0
         version: 8.48.0
@@ -2988,6 +2991,9 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -3288,6 +3294,10 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  dev@0.1.3:
+    resolution: {integrity: sha512-flCHQwAkXk3+1up/wo93Ms9E5Wf9K28ZGA7Oz55nBZ8OTdPPhyvZrwsT+twtySTFHIwv0w9CUNtagZgu1MgzXQ==}
+    hasBin: true
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -3606,6 +3616,9 @@ packages:
     resolution: {integrity: sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==}
     engines: {node: '>= 12'}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -3868,6 +3881,11 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  inotify@1.4.6:
+    resolution: {integrity: sha512-WW8/uqIA04O3AePQVe/Ms3ZLR0yGamaz8YOEpaXc4WBAGOPZfzu58wWErEPSUYaPyDrJRIeCn6PEIQgC1ZyQ5w==}
+    engines: {node: '>=0.8'}
+    os: [linux]
 
   input-otp@1.4.2:
     resolution: {integrity: sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==}
@@ -4567,6 +4585,9 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nan@2.26.2:
+    resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -8757,6 +8778,10 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -9032,6 +9057,10 @@ snapshots:
   detect-newline@3.1.0: {}
 
   detect-node-es@1.1.0: {}
+
+  dev@0.1.3:
+    dependencies:
+      inotify: 1.4.6
 
   dir-glob@3.0.1:
     dependencies:
@@ -9495,6 +9524,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  file-uri-to-path@1.0.0: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -9758,6 +9789,11 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  inotify@1.4.6:
+    dependencies:
+      bindings: 1.5.0
+      nan: 2.26.2
 
   input-otp@1.4.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
@@ -10621,6 +10657,8 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
 
   ms@2.1.3: {}
+
+  nan@2.26.2: {}
 
   nanoid@3.3.11: {}
 

--- a/src/app/dashboard/operations/page.tsx
+++ b/src/app/dashboard/operations/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next';
+import { SetupDiagnosticsPanel } from '@/features/operations/components/SetupDiagnosticsPanel';
+import { getSetupDiagnostics } from '@/lib/diagnostics/setup';
+
+export const metadata: Metadata = {
+  title: 'Operations | Stock Tracker',
+  description: 'Product readiness diagnostics'
+};
+
+export const dynamic = 'force-dynamic';
+
+export default async function OperationsPage() {
+  const diagnostics = await getSetupDiagnostics();
+
+  return (
+    <div className='flex-1 space-y-4 p-4 pt-6'>
+      <SetupDiagnosticsPanel diagnostics={diagnostics} />
+    </div>
+  );
+}

--- a/src/constants/data.ts
+++ b/src/constants/data.ts
@@ -28,6 +28,14 @@ export const navItems: NavItem[] = [
     isActive: false,
     shortcut: ['c', 'c'],
     items: []
+  },
+  {
+    title: 'Operations',
+    url: '/dashboard/operations',
+    icon: 'settings',
+    isActive: false,
+    shortcut: ['o', 'o'],
+    items: []
   }
 ];
 

--- a/src/features/operations/components/SetupDiagnosticsPanel.tsx
+++ b/src/features/operations/components/SetupDiagnosticsPanel.tsx
@@ -1,0 +1,141 @@
+import type {
+  DiagnosticStatus,
+  SetupDiagnosticCheck,
+  SetupDiagnostics
+} from '@/lib/diagnostics/setup';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Separator } from '@/components/ui/separator';
+import { cn } from '@/lib/utils';
+import {
+  IconAlertTriangle,
+  IconCircleCheck,
+  IconInfoCircle
+} from '@tabler/icons-react';
+
+interface SetupDiagnosticsPanelProps {
+  diagnostics: SetupDiagnostics;
+}
+
+const STATUS_META: Record<
+  DiagnosticStatus,
+  {
+    label: string;
+    badgeClassName: string;
+    iconClassName: string;
+    Icon: typeof IconCircleCheck;
+  }
+> = {
+  ready: {
+    label: 'Ready',
+    badgeClassName:
+      'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950 dark:text-emerald-300',
+    iconClassName: 'text-emerald-600 dark:text-emerald-400',
+    Icon: IconCircleCheck
+  },
+  warning: {
+    label: 'Warning',
+    badgeClassName:
+      'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-300',
+    iconClassName: 'text-amber-600 dark:text-amber-400',
+    Icon: IconInfoCircle
+  },
+  blocked: {
+    label: 'Blocked',
+    badgeClassName:
+      'border-red-200 bg-red-50 text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-300',
+    iconClassName: 'text-red-600 dark:text-red-400',
+    Icon: IconAlertTriangle
+  }
+};
+
+function DiagnosticCard({ check }: { check: SetupDiagnosticCheck }) {
+  const meta = STATUS_META[check.status];
+  const StatusIcon = meta.Icon;
+
+  return (
+    <Card className='gap-4'>
+      <CardHeader className='gap-3'>
+        <div className='flex items-start justify-between gap-4'>
+          <div className='flex min-w-0 items-start gap-3'>
+            <StatusIcon
+              aria-hidden='true'
+              className={cn('mt-0.5 size-5 shrink-0', meta.iconClassName)}
+            />
+            <div className='min-w-0 space-y-1'>
+              <CardTitle className='text-base'>{check.title}</CardTitle>
+              <CardDescription>{check.summary}</CardDescription>
+            </div>
+          </div>
+          <Badge variant='outline' className={meta.badgeClassName}>
+            {meta.label}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className='space-y-4'>
+        <Separator />
+        <ul className='text-muted-foreground space-y-2 text-sm'>
+          {check.details.map((detail) => (
+            <li key={detail} className='leading-relaxed'>
+              {detail}
+            </li>
+          ))}
+        </ul>
+        {check.remediation ? (
+          <div className='bg-muted/50 rounded-lg border p-3 text-sm'>
+            <div className='font-medium'>Remediation</div>
+            <p className='text-muted-foreground mt-1 leading-relaxed'>
+              {check.remediation}
+            </p>
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function SetupDiagnosticsPanel({
+  diagnostics
+}: SetupDiagnosticsPanelProps) {
+  const meta = STATUS_META[diagnostics.status];
+  const StatusIcon = meta.Icon;
+
+  return (
+    <div className='space-y-6'>
+      <div className='flex flex-col gap-4 md:flex-row md:items-start md:justify-between'>
+        <div className='space-y-2'>
+          <div className='flex items-center gap-3'>
+            <StatusIcon
+              aria-hidden='true'
+              className={cn('size-6', meta.iconClassName)}
+            />
+            <h1 className='text-3xl font-bold tracking-normal'>Operations</h1>
+          </div>
+          <p className='text-muted-foreground max-w-3xl text-sm leading-relaxed'>
+            {diagnostics.summary}
+          </p>
+        </div>
+        <div className='flex flex-wrap items-center gap-3 md:justify-end'>
+          <Badge variant='outline' className={meta.badgeClassName}>
+            Overall: {meta.label}
+          </Badge>
+          <span className='text-muted-foreground text-xs'>
+            Generated {diagnostics.generatedAt}
+          </span>
+        </div>
+      </div>
+
+      <div className='grid grid-cols-1 gap-4 xl:grid-cols-3'>
+        {diagnostics.checks.map((check) => (
+          <DiagnosticCard key={check.id} check={check} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/operations/components/__tests__/setup-diagnostics-panel.test.tsx
+++ b/src/features/operations/components/__tests__/setup-diagnostics-panel.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { SetupDiagnosticsPanel } from '../SetupDiagnosticsPanel';
+import type { SetupDiagnostics } from '@/lib/diagnostics/setup';
+
+const diagnostics: SetupDiagnostics = {
+  status: 'blocked',
+  generatedAt: '2026-04-28T03:00:00.000Z',
+  summary: 'Setup is blocked until required configuration is completed.',
+  checks: [
+    {
+      id: 'clerk',
+      title: 'Clerk',
+      status: 'ready',
+      summary: 'Authentication configuration is ready.',
+      details: [
+        'Required Clerk environment variables are present.',
+        'Authenticated dashboard session is active.'
+      ],
+      remediation: null
+    },
+    {
+      id: 'supabase',
+      title: 'Supabase',
+      status: 'blocked',
+      summary: 'Watchlist persistence setup is incomplete.',
+      details: ['Clerk JWT template "supabase" was not found.'],
+      remediation:
+        'Configure Supabase URL/key values and Clerk JWT template "supabase" for Clerk-issued Supabase tokens.'
+    },
+    {
+      id: 'longbridge',
+      title: 'Longbridge',
+      status: 'warning',
+      summary: 'Market data credentials need review.',
+      details: ['Credential verification was skipped.'],
+      remediation: 'Confirm Longbridge credentials on the server.'
+    }
+  ]
+};
+
+describe('SetupDiagnosticsPanel', () => {
+  it('renders overall status, check statuses, details, and remediation', () => {
+    render(<SetupDiagnosticsPanel diagnostics={diagnostics} />);
+
+    expect(
+      screen.getByRole('heading', { name: 'Operations' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Overall: Blocked')).toBeInTheDocument();
+    expect(
+      screen.getByText('Generated 2026-04-28T03:00:00.000Z')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Clerk')).toBeInTheDocument();
+    expect(screen.getByText('Supabase')).toBeInTheDocument();
+    expect(screen.getByText('Longbridge')).toBeInTheDocument();
+    expect(
+      screen.getByText('Clerk JWT template "supabase" was not found.')
+    ).toBeInTheDocument();
+    expect(screen.getAllByText('Remediation')).toHaveLength(2);
+  });
+
+  it('does not render secret sentinel values that are not part of diagnostics', () => {
+    const { container } = render(
+      <SetupDiagnosticsPanel diagnostics={diagnostics} />
+    );
+
+    expect(container).not.toHaveTextContent('sk_test_secret');
+    expect(container).not.toHaveTextContent('longbridge_access_token');
+    expect(container).not.toHaveTextContent('supabase_publishable_secret');
+  });
+});

--- a/src/lib/diagnostics/setup.test.ts
+++ b/src/lib/diagnostics/setup.test.ts
@@ -1,0 +1,175 @@
+/**
+ * @jest-environment node
+ */
+import { auth } from '@clerk/nextjs/server';
+import { getSetupDiagnostics } from './setup';
+
+jest.mock('server-only', () => ({}));
+
+jest.mock('@clerk/nextjs/server', () => ({
+  auth: jest.fn()
+}));
+
+const mockAuth = auth as jest.Mock;
+const originalEnv = process.env;
+
+function configureReadyEnv() {
+  process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = 'pk_test_value';
+  process.env.CLERK_SECRET_KEY = 'sk_test_secret';
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+  process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY =
+    'supabase_publishable_secret';
+  delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  process.env.LONGPORT_APP_KEY = 'longbridge_app_key';
+  process.env.LONGPORT_APP_SECRET = 'longbridge_app_secret';
+  process.env.LONGPORT_ACCESS_TOKEN = 'longbridge_access_token';
+}
+
+function findCheck(
+  diagnostics: Awaited<ReturnType<typeof getSetupDiagnostics>>,
+  id: string
+) {
+  const check = diagnostics.checks.find((candidate) => candidate.id === id);
+  if (!check) {
+    throw new Error(`Missing diagnostic check: ${id}`);
+  }
+  return check;
+}
+
+describe('getSetupDiagnostics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    configureReadyEnv();
+    mockAuth.mockResolvedValue({
+      userId: 'user_123',
+      getToken: jest.fn().mockResolvedValue('supabase-jwt')
+    });
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns ready checks when Clerk, Supabase, and Longbridge are configured', async () => {
+    const diagnostics = await getSetupDiagnostics();
+
+    expect(diagnostics.status).toBe('ready');
+    expect(diagnostics.checks).toHaveLength(3);
+    expect(diagnostics.checks.map((check) => check.status)).toEqual([
+      'ready',
+      'ready',
+      'ready'
+    ]);
+    expect(findCheck(diagnostics, 'supabase').details).toContain(
+      'Clerk JWT template "supabase" returned a token.'
+    );
+  });
+
+  it('reports missing environment variables without exposing configured values', async () => {
+    delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    delete process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY;
+    delete process.env.LONGPORT_APP_KEY;
+
+    const diagnostics = await getSetupDiagnostics();
+
+    expect(diagnostics.status).toBe('blocked');
+    expect(findCheck(diagnostics, 'clerk').status).toBe('blocked');
+    expect(findCheck(diagnostics, 'supabase').status).toBe('blocked');
+    expect(findCheck(diagnostics, 'longbridge').status).toBe('blocked');
+    expect(JSON.stringify(diagnostics)).toContain(
+      'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY'
+    );
+    expect(JSON.stringify(diagnostics)).not.toContain('sk_test_secret');
+    expect(JSON.stringify(diagnostics)).not.toContain(
+      'longbridge_access_token'
+    );
+  });
+
+  it('accepts the legacy Supabase anon key when the publishable key is missing', async () => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY;
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'legacy_anon_secret';
+
+    const diagnostics = await getSetupDiagnostics();
+
+    const supabase = findCheck(diagnostics, 'supabase');
+    expect(supabase.status).toBe('ready');
+    expect(supabase.details).toContain(
+      'Using legacy Supabase anon key environment variable.'
+    );
+    expect(JSON.stringify(diagnostics)).not.toContain('legacy_anon_secret');
+  });
+
+  it('blocks Supabase when the URL is not an absolute URL', async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'not-a-url';
+
+    const diagnostics = await getSetupDiagnostics();
+
+    const supabase = findCheck(diagnostics, 'supabase');
+    expect(supabase.status).toBe('blocked');
+    expect(supabase.details).toContain(
+      'NEXT_PUBLIC_SUPABASE_URL must be a valid absolute URL.'
+    );
+  });
+
+  it('blocks Supabase when the Clerk JWT template is missing', async () => {
+    const getToken = jest.fn().mockRejectedValue(
+      Object.assign(new Error('Not Found'), {
+        clerkError: true,
+        code: 'api_response_error',
+        status: 404
+      })
+    );
+    mockAuth.mockResolvedValue({ userId: 'user_123', getToken });
+
+    const diagnostics = await getSetupDiagnostics();
+
+    expect(getToken).toHaveBeenCalledWith({ template: 'supabase' });
+    const supabase = findCheck(diagnostics, 'supabase');
+    expect(supabase.status).toBe('blocked');
+    expect(supabase.details).toContain(
+      'Clerk JWT template "supabase" was not found.'
+    );
+  });
+
+  it('blocks Supabase when the Clerk JWT template returns an empty token', async () => {
+    const getToken = jest.fn().mockResolvedValue('');
+    mockAuth.mockResolvedValue({ userId: 'user_123', getToken });
+
+    const diagnostics = await getSetupDiagnostics();
+
+    const supabase = findCheck(diagnostics, 'supabase');
+    expect(supabase.status).toBe('blocked');
+    expect(supabase.details).toContain(
+      'Clerk JWT template "supabase" returned no token.'
+    );
+  });
+
+  it('warns when an unexpected Clerk token verification error occurs', async () => {
+    const getToken = jest.fn().mockRejectedValue(new Error('temporary outage'));
+    mockAuth.mockResolvedValue({ userId: 'user_123', getToken });
+
+    const diagnostics = await getSetupDiagnostics();
+
+    const supabase = findCheck(diagnostics, 'supabase');
+    expect(diagnostics.status).toBe('warning');
+    expect(supabase.status).toBe('warning');
+    expect(supabase.details).toContain(
+      'Clerk JWT template "supabase" could not be verified.'
+    );
+  });
+
+  it('blocks Longbridge when any credential variable is missing', async () => {
+    delete process.env.LONGPORT_ACCESS_TOKEN;
+
+    const diagnostics = await getSetupDiagnostics();
+
+    const longbridge = findCheck(diagnostics, 'longbridge');
+    expect(longbridge.status).toBe('blocked');
+    expect(longbridge.details).toContain(
+      'Missing environment variables: LONGPORT_ACCESS_TOKEN.'
+    );
+    expect(JSON.stringify(diagnostics)).not.toContain('longbridge_app_secret');
+  });
+});

--- a/src/lib/diagnostics/setup.ts
+++ b/src/lib/diagnostics/setup.ts
@@ -1,0 +1,316 @@
+import 'server-only';
+
+import { auth } from '@clerk/nextjs/server';
+import { SUPABASE_JWT_TEMPLATE } from '@/lib/supabase/server';
+
+export type DiagnosticStatus = 'ready' | 'warning' | 'blocked';
+
+export type DiagnosticCheckId = 'clerk' | 'supabase' | 'longbridge';
+
+export interface SetupDiagnosticCheck {
+  id: DiagnosticCheckId;
+  title: string;
+  status: DiagnosticStatus;
+  summary: string;
+  details: string[];
+  remediation: string | null;
+}
+
+export interface SetupDiagnostics {
+  status: DiagnosticStatus;
+  generatedAt: string;
+  summary: string;
+  checks: SetupDiagnosticCheck[];
+}
+
+interface AuthState {
+  userId: string | null;
+  getToken?: (options: { template: string }) => Promise<string | null>;
+  error?: unknown;
+}
+
+const CLERK_ENV_KEYS = [
+  'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY',
+  'CLERK_SECRET_KEY'
+] as const;
+
+const LONGBRIDGE_ENV_KEYS = [
+  'LONGPORT_APP_KEY',
+  'LONGPORT_APP_SECRET',
+  'LONGPORT_ACCESS_TOKEN'
+] as const;
+
+function hasEnvValue(key: string): boolean {
+  return Boolean(process.env[key]?.trim());
+}
+
+function getMissingEnvKeys(keys: readonly string[]): string[] {
+  return keys.filter((key) => !hasEnvValue(key));
+}
+
+function isValidUrl(value: string | undefined): boolean {
+  if (!value?.trim()) {
+    return false;
+  }
+
+  try {
+    const url = new URL(value);
+    return Boolean(url.protocol && url.host);
+  } catch {
+    return false;
+  }
+}
+
+function isClerkTemplateMissingError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+
+  const candidate = error as {
+    status?: unknown;
+    clerkError?: unknown;
+    code?: unknown;
+    message?: unknown;
+  };
+
+  return (
+    candidate.clerkError === true &&
+    candidate.status === 404 &&
+    (candidate.code === 'api_response_error' ||
+      (typeof candidate.message === 'string' &&
+        candidate.message.toLowerCase().includes('not found')))
+  );
+}
+
+function joinKeys(keys: string[]): string {
+  return keys.join(', ');
+}
+
+function createClerkCheck(authState: AuthState): SetupDiagnosticCheck {
+  const missingKeys = getMissingEnvKeys(CLERK_ENV_KEYS);
+  const details: string[] = [];
+
+  if (missingKeys.length > 0) {
+    details.push(`Missing environment variables: ${joinKeys(missingKeys)}.`);
+  } else {
+    details.push('Required Clerk environment variables are present.');
+  }
+
+  if (authState.error) {
+    details.push('Clerk server authentication could not be evaluated.');
+  } else if (!authState.userId) {
+    details.push('No authenticated dashboard session was found.');
+  } else {
+    details.push('Authenticated dashboard session is active.');
+  }
+
+  if (missingKeys.length > 0 || authState.error || !authState.userId) {
+    return {
+      id: 'clerk',
+      title: 'Clerk',
+      status: 'blocked',
+      summary: 'Authentication setup needs attention.',
+      details,
+      remediation:
+        'Configure Clerk publishable and secret keys, then sign in to the dashboard again.'
+    };
+  }
+
+  return {
+    id: 'clerk',
+    title: 'Clerk',
+    status: 'ready',
+    summary: 'Authentication configuration is ready.',
+    details,
+    remediation: null
+  };
+}
+
+async function createSupabaseCheck(
+  authState: AuthState
+): Promise<SetupDiagnosticCheck> {
+  const details: string[] = [];
+  const blockedReasons: string[] = [];
+  const warningReasons: string[] = [];
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const hasPublishableKey = hasEnvValue(
+    'NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY'
+  );
+  const hasLegacyAnonKey = hasEnvValue('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+
+  if (!hasEnvValue('NEXT_PUBLIC_SUPABASE_URL')) {
+    blockedReasons.push('Missing environment variable: NEXT_PUBLIC_SUPABASE_URL.');
+  } else if (!isValidUrl(supabaseUrl)) {
+    blockedReasons.push(
+      'NEXT_PUBLIC_SUPABASE_URL must be a valid absolute URL.'
+    );
+  } else {
+    details.push('Supabase URL is present and has a valid URL shape.');
+  }
+
+  if (!hasPublishableKey && !hasLegacyAnonKey) {
+    blockedReasons.push(
+      'Missing environment variable: NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY or legacy NEXT_PUBLIC_SUPABASE_ANON_KEY.'
+    );
+  } else if (hasPublishableKey) {
+    details.push('Supabase publishable key environment variable is present.');
+  } else {
+    details.push('Using legacy Supabase anon key environment variable.');
+  }
+
+  if (authState.error) {
+    warningReasons.push(
+      'Clerk auth failed before the Supabase JWT template could be checked.'
+    );
+  } else if (!authState.userId || !authState.getToken) {
+    warningReasons.push(
+      'No authenticated Clerk session is available to verify the Supabase JWT template.'
+    );
+  } else {
+    try {
+      const token = await authState.getToken({ template: SUPABASE_JWT_TEMPLATE });
+
+      if (token?.trim()) {
+        details.push(
+          `Clerk JWT template "${SUPABASE_JWT_TEMPLATE}" returned a token.`
+        );
+      } else {
+        blockedReasons.push(
+          `Clerk JWT template "${SUPABASE_JWT_TEMPLATE}" returned no token.`
+        );
+      }
+    } catch (error) {
+      if (isClerkTemplateMissingError(error)) {
+        blockedReasons.push(
+          `Clerk JWT template "${SUPABASE_JWT_TEMPLATE}" was not found.`
+        );
+      } else {
+        warningReasons.push(
+          `Clerk JWT template "${SUPABASE_JWT_TEMPLATE}" could not be verified.`
+        );
+      }
+    }
+  }
+
+  details.push(...blockedReasons, ...warningReasons);
+
+  if (blockedReasons.length > 0) {
+    return {
+      id: 'supabase',
+      title: 'Supabase',
+      status: 'blocked',
+      summary: 'Watchlist persistence setup is incomplete.',
+      details,
+      remediation:
+        'Configure Supabase URL/key values and Clerk JWT template "supabase" for Clerk-issued Supabase tokens.'
+    };
+  }
+
+  if (warningReasons.length > 0) {
+    return {
+      id: 'supabase',
+      title: 'Supabase',
+      status: 'warning',
+      summary: 'Supabase config is present, but token verification is incomplete.',
+      details,
+      remediation:
+        'Retry while signed in. If the warning persists, confirm Clerk can issue the Supabase JWT template.'
+    };
+  }
+
+  return {
+    id: 'supabase',
+    title: 'Supabase',
+    status: 'ready',
+    summary: 'Watchlist persistence configuration is ready.',
+    details,
+    remediation: null
+  };
+}
+
+function createLongbridgeCheck(): SetupDiagnosticCheck {
+  const missingKeys = getMissingEnvKeys(LONGBRIDGE_ENV_KEYS);
+  const details =
+    missingKeys.length > 0
+      ? [`Missing environment variables: ${joinKeys(missingKeys)}.`]
+      : ['Required Longbridge environment variables are present.'];
+
+  if (missingKeys.length > 0) {
+    return {
+      id: 'longbridge',
+      title: 'Longbridge',
+      status: 'blocked',
+      summary: 'Market data credentials are incomplete.',
+      details,
+      remediation:
+        'Configure Longbridge app key, app secret, and access token on the server.'
+    };
+  }
+
+  return {
+    id: 'longbridge',
+    title: 'Longbridge',
+    status: 'ready',
+    summary: 'Market data credentials are configured.',
+    details,
+    remediation: null
+  };
+}
+
+function getOverallStatus(checks: SetupDiagnosticCheck[]): DiagnosticStatus {
+  if (checks.some((check) => check.status === 'blocked')) {
+    return 'blocked';
+  }
+
+  if (checks.some((check) => check.status === 'warning')) {
+    return 'warning';
+  }
+
+  return 'ready';
+}
+
+function getOverallSummary(status: DiagnosticStatus): string {
+  switch (status) {
+    case 'ready':
+      return 'All setup checks are ready.';
+    case 'warning':
+      return 'Setup is mostly ready, with one check needing review.';
+    case 'blocked':
+      return 'Setup is blocked until required configuration is completed.';
+    default:
+      return 'Setup diagnostics completed.';
+  }
+}
+
+async function getAuthState(): Promise<AuthState> {
+  try {
+    const authResult = await auth();
+    return {
+      userId: authResult.userId,
+      getToken: authResult.getToken
+    };
+  } catch (error) {
+    return {
+      userId: null,
+      error
+    };
+  }
+}
+
+export async function getSetupDiagnostics(): Promise<SetupDiagnostics> {
+  const authState = await getAuthState();
+  const checks = [
+    createClerkCheck(authState),
+    await createSupabaseCheck(authState),
+    createLongbridgeCheck()
+  ];
+  const status = getOverallStatus(checks);
+
+  return {
+    status,
+    generatedAt: new Date().toISOString(),
+    summary: getOverallSummary(status),
+    checks
+  };
+}


### PR DESCRIPTION
## Summary
- Add a Clerk-protected Operations page for product readiness checks
- Surface Clerk, Supabase, and Longbridge setup status in-app with remediation guidance
- Add a sidebar link for quick access to diagnostics

## Testing
- Added unit coverage for diagnostics status handling and environment edge cases
- Added UI tests for the Operations diagnostics panel