### PR TITLE
Add watchlist metadata support

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
+    "dev": "^0.1.3",
     "eslint": "8.48.0",
     "eslint-config-next": "15.1.0",
     "input-otp": "^1.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      dev:
+        specifier: ^0.1.3
+        version: 0.1.3
       eslint:
         specifier: 8.48.0
         version: 8.48.0
@@ -2988,6 +2991,9 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -3288,6 +3294,10 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  dev@0.1.3:
+    resolution: {integrity: sha512-flCHQwAkXk3+1up/wo93Ms9E5Wf9K28ZGA7Oz55nBZ8OTdPPhyvZrwsT+twtySTFHIwv0w9CUNtagZgu1MgzXQ==}
+    hasBin: true
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -3606,6 +3616,9 @@ packages:
     resolution: {integrity: sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==}
     engines: {node: '>= 12'}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -3868,6 +3881,11 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  inotify@1.4.6:
+    resolution: {integrity: sha512-WW8/uqIA04O3AePQVe/Ms3ZLR0yGamaz8YOEpaXc4WBAGOPZfzu58wWErEPSUYaPyDrJRIeCn6PEIQgC1ZyQ5w==}
+    engines: {node: '>=0.8'}
+    os: [linux]
 
   input-otp@1.4.2:
     resolution: {integrity: sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==}
@@ -4567,6 +4585,9 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nan@2.26.2:
+    resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -8757,6 +8778,10 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -9032,6 +9057,10 @@ snapshots:
   detect-newline@3.1.0: {}
 
   detect-node-es@1.1.0: {}
+
+  dev@0.1.3:
+    dependencies:
+      inotify: 1.4.6
 
   dir-glob@3.0.1:
     dependencies:
@@ -9495,6 +9524,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  file-uri-to-path@1.0.0: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -9758,6 +9789,11 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  inotify@1.4.6:
+    dependencies:
+      bindings: 1.5.0
+      nan: 2.26.2
 
   input-otp@1.4.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
@@ -10621,6 +10657,8 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
 
   ms@2.1.3: {}
+
+  nan@2.26.2: {}
 
   nanoid@3.3.11: {}
 

--- a/src/app/api/watchlist/route.test.ts
+++ b/src/app/api/watchlist/route.test.ts
@@ -1,32 +1,51 @@
 /**
  * @jest-environment node
  */
-import { POST, GET } from './route';
+import { POST, GET, PATCH } from './route';
 import { NextRequest } from 'next/server';
 import { auth } from '@clerk/nextjs/server';
 import { SupabaseAuthConfigError } from '@/lib/supabase/server';
 import {
-  getWatchlist,
+  getWatchlistItems,
   addToWatchlist,
-  removeFromWatchlist
+  removeFromWatchlist,
+  updateWatchlistItemMetadata,
+  reorderWatchlistItems
 } from '@/lib/watchlist/storage';
+import type { WatchlistItem } from '@/types/watchlist';
 
-// Mock dependencies
 jest.mock('@clerk/nextjs/server', () => ({
   auth: jest.fn()
 }));
 
 jest.mock('@/lib/watchlist/storage', () => ({
-  getWatchlist: jest.fn(),
+  getWatchlistItems: jest.fn(),
   addToWatchlist: jest.fn(),
-  removeFromWatchlist: jest.fn()
+  removeFromWatchlist: jest.fn(),
+  updateWatchlistItemMetadata: jest.fn(),
+  reorderWatchlistItems: jest.fn()
 }));
+
+function createItem(overrides: Partial<WatchlistItem>): WatchlistItem {
+  return {
+    id: 'item-1',
+    symbol: 'AAPL',
+    exchange: null,
+    note: null,
+    sort_order: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides
+  };
+}
 
 describe('/api/watchlist', () => {
   const mockAuth = auth as jest.Mock;
-  const mockGet = getWatchlist as jest.Mock;
+  const mockGetItems = getWatchlistItems as jest.Mock;
   const mockAdd = addToWatchlist as jest.Mock;
   const mockRemove = removeFromWatchlist as jest.Mock;
+  const mockUpdate = updateWatchlistItemMetadata as jest.Mock;
+  const mockReorder = reorderWatchlistItems as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -35,23 +54,27 @@ describe('/api/watchlist', () => {
   describe('GET', () => {
     it('returns 401 if user is not authenticated', async () => {
       mockAuth.mockResolvedValue({ userId: null });
-      const req = new NextRequest('http://localhost/api/watchlist');
-      const res = await GET(req);
+      const res = await GET();
       expect(res.status).toBe(401);
     });
 
-    it('returns watchlist if user is authenticated', async () => {
-      mockAuth.mockResolvedValue({ userId: 'user_123' });
-      mockGet.mockResolvedValue(['AAPL', 'MSFT']);
+    it('returns watchlist symbols and item metadata if user is authenticated', async () => {
+      const items = [
+        createItem({ id: 'item-1', symbol: 'AAPL', exchange: 'NASDAQ' }),
+        createItem({ id: 'item-2', symbol: 'MSFT', note: 'AI' })
+      ];
 
-      const req = new NextRequest('http://localhost/api/watchlist');
-      const res = await GET(req);
+      mockAuth.mockResolvedValue({ userId: 'user_123' });
+      mockGetItems.mockResolvedValue(items);
+
+      const res = await GET();
       const json = await res.json();
 
       expect(res.status).toBe(200);
       expect(json.success).toBe(true);
       expect(json.data.watchlist).toEqual(['AAPL', 'MSFT']);
-      expect(mockGet).toHaveBeenCalledWith('user_123');
+      expect(json.data.items).toEqual(items);
+      expect(mockGetItems).toHaveBeenCalledWith('user_123');
     });
   });
 
@@ -66,13 +89,26 @@ describe('/api/watchlist', () => {
       expect(res.status).toBe(401);
     });
 
-    it('adds symbol to watchlist', async () => {
+    it('adds symbol with normalized metadata', async () => {
+      const items = [
+        createItem({
+          symbol: 'AAPL',
+          exchange: 'NASDAQ',
+          note: 'Core holding'
+        })
+      ];
+
       mockAuth.mockResolvedValue({ userId: 'user_123' });
-      mockAdd.mockResolvedValue(['AAPL']);
+      mockAdd.mockResolvedValue(items);
 
       const req = new NextRequest('http://localhost/api/watchlist', {
         method: 'POST',
-        body: JSON.stringify({ action: 'add', symbol: 'AAPL' })
+        body: JSON.stringify({
+          action: 'add',
+          symbol: 'aapl',
+          exchange: ' nasdaq ',
+          note: ' Core holding '
+        })
       });
       const res = await POST(req);
       const json = await res.json();
@@ -80,12 +116,18 @@ describe('/api/watchlist', () => {
       expect(res.status).toBe(200);
       expect(json.success).toBe(true);
       expect(json.data.watchlist).toEqual(['AAPL']);
-      expect(mockAdd).toHaveBeenCalledWith('user_123', 'AAPL');
+      expect(json.data.items).toEqual(items);
+      expect(mockAdd).toHaveBeenCalledWith('user_123', 'AAPL', {
+        exchange: 'NASDAQ',
+        note: 'Core holding'
+      });
     });
 
     it('removes symbol from watchlist', async () => {
+      const items = [createItem({ id: 'item-2', symbol: 'MSFT' })];
+
       mockAuth.mockResolvedValue({ userId: 'user_123' });
-      mockRemove.mockResolvedValue(['MSFT']); // assume AAPL removed, MSFT remains
+      mockRemove.mockResolvedValue(items);
 
       const req = new NextRequest('http://localhost/api/watchlist', {
         method: 'POST',
@@ -97,14 +139,33 @@ describe('/api/watchlist', () => {
       expect(res.status).toBe(200);
       expect(json.success).toBe(true);
       expect(json.data.watchlist).toEqual(['MSFT']);
-      expect(json.data.watchlist).toEqual(['MSFT']);
+      expect(json.data.items).toEqual(items);
       expect(mockRemove).toHaveBeenCalledWith('user_123', 'AAPL');
+    });
+
+    it('returns 400 if note exceeds 500 characters', async () => {
+      mockAuth.mockResolvedValue({ userId: 'user_123' });
+
+      const req = new NextRequest('http://localhost/api/watchlist', {
+        method: 'POST',
+        body: JSON.stringify({
+          action: 'add',
+          symbol: 'AAPL',
+          note: 'a'.repeat(501)
+        })
+      });
+      const res = await POST(req);
+      const json = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(json.success).toBe(false);
+      expect(json.error.message).toBe('Note must be 500 characters or less');
+      expect(mockAdd).not.toHaveBeenCalled();
     });
 
     it('returns 500 if storage fails', async () => {
       mockAuth.mockResolvedValue({ userId: 'user_123' });
-      const error = new Error('Database error');
-      mockAdd.mockRejectedValue(error);
+      mockAdd.mockRejectedValue(new Error('Database error'));
 
       const req = new NextRequest('http://localhost/api/watchlist', {
         method: 'POST',
@@ -142,17 +203,131 @@ describe('/api/watchlist', () => {
     });
   });
 
-  describe('misconfiguration handling', () => {
-    it('returns 503 on GET if watchlist auth is misconfigured', async () => {
+  describe('PATCH', () => {
+    it('returns 401 if user is not authenticated', async () => {
+      mockAuth.mockResolvedValue({ userId: null });
+      const req = new NextRequest('http://localhost/api/watchlist', {
+        method: 'PATCH',
+        body: JSON.stringify({ action: 'update', symbol: 'AAPL' })
+      });
+      const res = await PATCH(req);
+      expect(res.status).toBe(401);
+    });
+
+    it('updates item metadata', async () => {
+      const items = [
+        createItem({ symbol: 'AAPL', exchange: 'NYSE', note: 'Dividend' })
+      ];
+
       mockAuth.mockResolvedValue({ userId: 'user_123' });
-      mockGet.mockRejectedValue(
+      mockUpdate.mockResolvedValue(items);
+
+      const req = new NextRequest('http://localhost/api/watchlist', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          action: 'update',
+          symbol: 'aapl',
+          exchange: ' nyse ',
+          note: ' Dividend '
+        })
+      });
+      const res = await PATCH(req);
+      const json = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(json.data.watchlist).toEqual(['AAPL']);
+      expect(json.data.items).toEqual(items);
+      expect(mockUpdate).toHaveBeenCalledWith('user_123', 'AAPL', {
+        exchange: 'NYSE',
+        note: 'Dividend'
+      });
+    });
+
+    it('persists reorder items', async () => {
+      const items = [
+        createItem({ symbol: 'MSFT', sort_order: 0 }),
+        createItem({ symbol: 'AAPL', sort_order: 1 })
+      ];
+
+      mockAuth.mockResolvedValue({ userId: 'user_123' });
+      mockReorder.mockResolvedValue(items);
+
+      const req = new NextRequest('http://localhost/api/watchlist', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          action: 'reorder',
+          items: [
+            { symbol: 'msft', sort_order: 0 },
+            { symbol: 'aapl', sort_order: 1 }
+          ]
+        })
+      });
+      const res = await PATCH(req);
+      const json = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(json.data.watchlist).toEqual(['MSFT', 'AAPL']);
+      expect(mockReorder).toHaveBeenCalledWith('user_123', [
+        { symbol: 'MSFT', sort_order: 0 },
+        { symbol: 'AAPL', sort_order: 1 }
+      ]);
+    });
+
+    it('rejects invalid reorder sort_order values', async () => {
+      mockAuth.mockResolvedValue({ userId: 'user_123' });
+
+      const req = new NextRequest('http://localhost/api/watchlist', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          action: 'reorder',
+          items: [{ symbol: 'AAPL', sort_order: -1 }]
+        })
+      });
+      const res = await PATCH(req);
+      const json = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(json.success).toBe(false);
+      expect(json.error.message).toBe(
+        'sort_order must be a non-negative safe integer'
+      );
+      expect(mockReorder).not.toHaveBeenCalled();
+    });
+
+    it('returns 503 if patch storage auth is misconfigured', async () => {
+      mockAuth.mockResolvedValue({ userId: 'user_123' });
+      mockUpdate.mockRejectedValue(
         new SupabaseAuthConfigError(
           'Clerk Supabase JWT template is not configured'
         )
       );
 
-      const req = new NextRequest('http://localhost/api/watchlist');
-      const res = await GET(req);
+      const req = new NextRequest('http://localhost/api/watchlist', {
+        method: 'PATCH',
+        body: JSON.stringify({ action: 'update', symbol: 'AAPL' })
+      });
+      const res = await PATCH(req);
+      const json = await res.json();
+
+      expect(res.status).toBe(503);
+      expect(json.success).toBe(false);
+      expect(json.error).toEqual({
+        code: 'WATCHLIST_AUTH_MISCONFIGURED',
+        message: 'Watchlist authentication is not configured on the server.'
+      });
+    });
+  });
+
+  describe('misconfiguration handling', () => {
+    it('returns 503 on GET if watchlist auth is misconfigured', async () => {
+      mockAuth.mockResolvedValue({ userId: 'user_123' });
+      mockGetItems.mockRejectedValue(
+        new SupabaseAuthConfigError(
+          'Clerk Supabase JWT template is not configured'
+        )
+      );
+
+      const res = await GET();
       const json = await res.json();
 
       expect(res.status).toBe(503);

--- a/src/app/api/watchlist/route.ts
+++ b/src/app/api/watchlist/route.ts
@@ -4,15 +4,19 @@ import { isValidTicker, normalizeTicker } from '@/lib/validation/ticker';
 import { logger } from '@/lib/logger';
 import { isSupabaseAuthConfigError } from '@/lib/supabase/server';
 import {
-  getWatchlist,
+  getWatchlistItems,
   addToWatchlist,
-  removeFromWatchlist
+  removeFromWatchlist,
+  updateWatchlistItemMetadata,
+  reorderWatchlistItems
 } from '@/lib/watchlist/storage';
+import type { WatchlistItem } from '@/types/watchlist';
 
 /**
  * Action types for watchlist operations
  */
 export type WatchlistAction = 'add' | 'remove';
+export type WatchlistPatchAction = 'update' | 'reorder';
 
 /**
  * Request body structure for watchlist operations
@@ -20,6 +24,19 @@ export type WatchlistAction = 'add' | 'remove';
 export interface WatchlistRequestBody {
   action?: WatchlistAction;
   symbol?: string;
+  exchange?: unknown;
+  note?: unknown;
+}
+
+export interface WatchlistPatchRequestBody {
+  action?: WatchlistPatchAction;
+  symbol?: string;
+  exchange?: unknown;
+  note?: unknown;
+  items?: Array<{
+    symbol?: string;
+    sort_order?: unknown;
+  }>;
 }
 
 /**
@@ -29,6 +46,7 @@ export interface WatchlistResponse {
   success: true;
   data: {
     watchlist: string[];
+    items: WatchlistItem[];
   };
 }
 
@@ -69,6 +87,48 @@ function handleWatchlistAuthMisconfiguration(message: string, error: unknown) {
   });
 
   return createWatchlistAuthMisconfiguredResponse();
+}
+
+function createWatchlistResponse(items: WatchlistItem[]) {
+  return NextResponse.json({
+    success: true,
+    data: {
+      watchlist: items.map((item) => item.symbol),
+      items
+    }
+  });
+}
+
+function normalizeExchange(value: unknown): string | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== 'string') {
+    throw new Error('Exchange must be a string');
+  }
+
+  const trimmed = value.trim();
+  return trimmed ? trimmed.toUpperCase() : null;
+}
+
+function normalizeNote(value: unknown): string | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== 'string') {
+    throw new Error('Note must be a string');
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (trimmed.length > 500) {
+    throw new Error('Note must be 500 characters or less');
+  }
+
+  return trimmed;
+}
+
+function createValidationError(message: string) {
+  return NextResponse.json(
+    { success: false, error: { message } },
+    { status: 400 }
+  );
 }
 
 // Very simple in-memory stores keyed by client id (ip header) for rate limiting
@@ -112,11 +172,8 @@ export async function GET() {
   }
 
   try {
-    const list = await getWatchlist(userId);
-    return NextResponse.json({
-      success: true,
-      data: { watchlist: list }
-    });
+    const items = await getWatchlistItems(userId);
+    return createWatchlistResponse(items);
   } catch (error) {
     if (isSupabaseAuthConfigError(error)) {
       return handleWatchlistAuthMisconfiguration(
@@ -189,17 +246,26 @@ export async function POST(req: Request) {
   }
 
   try {
-    let list: string[];
+    let items: WatchlistItem[];
     if (action === 'add') {
-      list = await addToWatchlist(userId, symbol);
+      let exchange: string | null;
+      let note: string | null;
+
+      try {
+        exchange = normalizeExchange(body.exchange);
+        note = normalizeNote(body.note);
+      } catch (error) {
+        return createValidationError(
+          error instanceof Error ? error.message : 'Invalid metadata'
+        );
+      }
+
+      items = await addToWatchlist(userId, symbol, { exchange, note });
     } else {
-      list = await removeFromWatchlist(userId, symbol);
+      items = await removeFromWatchlist(userId, symbol);
     }
 
-    return NextResponse.json({
-      success: true,
-      data: { watchlist: list }
-    });
+    return createWatchlistResponse(items);
   } catch (error) {
     if (isSupabaseAuthConfigError(error)) {
       return handleWatchlistAuthMisconfiguration(
@@ -209,6 +275,124 @@ export async function POST(req: Request) {
     }
 
     logger.error('Watchlist update error', { error });
+    return NextResponse.json(
+      { success: false, error: { message: 'Failed to update watchlist' } },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(req: Request) {
+  const id = getClientId(req);
+  const rl = rateLimit(id);
+  if (!rl.allowed) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: { message: 'Rate limit exceeded. Try again later.' }
+      },
+      {
+        status: 429,
+        headers: rl.retryAfter
+          ? { 'Retry-After': String(rl.retryAfter) }
+          : undefined
+      }
+    );
+  }
+
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json(
+      { success: false, error: { message: 'Unauthorized' } },
+      { status: 401 }
+    );
+  }
+
+  let body: WatchlistPatchRequestBody;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json(
+      { success: false, error: { message: 'Invalid JSON body' } },
+      { status: 400 }
+    );
+  }
+
+  try {
+    if (body.action === 'update') {
+      const symbol = body.symbol ? normalizeTicker(body.symbol) : undefined;
+      if (!symbol || !isValidTicker(symbol)) {
+        return createValidationError('Invalid ticker symbol');
+      }
+
+      let exchange: string | null;
+      let note: string | null;
+
+      try {
+        exchange = normalizeExchange(body.exchange);
+        note = normalizeNote(body.note);
+      } catch (error) {
+        return createValidationError(
+          error instanceof Error ? error.message : 'Invalid metadata'
+        );
+      }
+
+      const items = await updateWatchlistItemMetadata(userId, symbol, {
+        exchange,
+        note
+      });
+
+      return createWatchlistResponse(items);
+    }
+
+    if (body.action === 'reorder') {
+      if (!Array.isArray(body.items)) {
+        return createValidationError("'items' must be an array");
+      }
+
+      const seen = new Set<string>();
+      const reorderItems: Array<{ symbol: string; sort_order: number }> = [];
+
+      for (const item of body.items) {
+        const symbol = item.symbol ? normalizeTicker(item.symbol) : undefined;
+        const sortOrder = item.sort_order;
+
+        if (!symbol || !isValidTicker(symbol)) {
+          return createValidationError('Invalid ticker symbol');
+        }
+
+        if (
+          typeof sortOrder !== 'number' ||
+          !Number.isSafeInteger(sortOrder) ||
+          sortOrder < 0
+        ) {
+          return createValidationError(
+            'sort_order must be a non-negative safe integer'
+          );
+        }
+
+        if (seen.has(symbol)) {
+          return createValidationError('Duplicate reorder symbol');
+        }
+
+        seen.add(symbol);
+        reorderItems.push({ symbol, sort_order: sortOrder });
+      }
+
+      const items = await reorderWatchlistItems(userId, reorderItems);
+      return createWatchlistResponse(items);
+    }
+
+    return createValidationError("'action' must be 'update' or 'reorder'");
+  } catch (error) {
+    if (isSupabaseAuthConfigError(error)) {
+      return handleWatchlistAuthMisconfiguration(
+        'Watchlist patch unavailable due to auth misconfiguration',
+        error
+      );
+    }
+
+    logger.error('Watchlist patch error', { error });
     return NextResponse.json(
       { success: false, error: { message: 'Failed to update watchlist' } },
       { status: 500 }

--- a/src/features/stock-dashboard/components/WatchlistCard.tsx
+++ b/src/features/stock-dashboard/components/WatchlistCard.tsx
@@ -1,9 +1,20 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog';
 import { normalizeTicker, validateTicker } from '@/lib/validation/ticker';
 import * as Sentry from '@sentry/nextjs';
 import { AddTickerError, getAddTickerError } from '../lib/add-ticker-error';
@@ -15,10 +26,25 @@ import { TickerErrorModal } from './TickerErrorModal';
 import { useDashboardStore } from '../store';
 import { toast } from 'sonner';
 import { logger } from '@/lib/logger';
+import type { WatchlistItem as ApiWatchlistItem } from '@/types/watchlist';
 
 type SpanLike = {
   setAttribute?: (key: string, value: string | number) => void;
 };
+
+type WatchlistMutationResponse =
+  | {
+      ok: true;
+    }
+  | {
+      ok: false;
+      status?: number;
+      message?: string;
+      error?: unknown;
+    };
+
+const NOTE_MAX_LENGTH = 500;
+const UNGROUPED_LABEL = 'Ungrouped';
 
 async function runWithSpan<T>(
   context: Parameters<typeof Sentry.startSpan>[0],
@@ -49,17 +75,147 @@ async function runWithSpan<T>(
   return fn();
 }
 
+function normalizeExchangeInput(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed ? trimmed.toUpperCase() : null;
+}
+
+function normalizeNoteInput(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function getGroupKey(item: ApiWatchlistItem): string {
+  return item.exchange?.trim() || '';
+}
+
+function getGroupLabel(groupKey: string): string {
+  return groupKey || UNGROUPED_LABEL;
+}
+
+function compareGroupKeys(a: string, b: string): number {
+  if (!a && !b) return 0;
+  if (!a) return 1;
+  if (!b) return -1;
+  return a.localeCompare(b);
+}
+
+function compareWatchlistItems(
+  a: ApiWatchlistItem,
+  b: ApiWatchlistItem
+): number {
+  const groupCompare = compareGroupKeys(getGroupKey(a), getGroupKey(b));
+  if (groupCompare !== 0) return groupCompare;
+
+  const sortA = a.sort_order ?? Number.MAX_SAFE_INTEGER;
+  const sortB = b.sort_order ?? Number.MAX_SAFE_INTEGER;
+  if (sortA !== sortB) return sortA - sortB;
+
+  const createdA = Date.parse(a.created_at) || 0;
+  const createdB = Date.parse(b.created_at) || 0;
+  if (createdA !== createdB) return createdA - createdB;
+
+  return a.symbol.localeCompare(b.symbol);
+}
+
+function getResponseItems(json: any): ApiWatchlistItem[] {
+  if (Array.isArray(json?.data?.items)) {
+    return json.data.items;
+  }
+
+  if (Array.isArray(json?.data?.watchlist)) {
+    const now = new Date().toISOString();
+    return json.data.watchlist.map((symbol: string) => ({
+      id: `watchlist-${symbol}`,
+      symbol,
+      exchange: null,
+      note: null,
+      sort_order: null,
+      created_at: now,
+      updated_at: now
+    }));
+  }
+
+  return [];
+}
+
+function createOptimisticItem(
+  symbol: string,
+  exchange: string | null,
+  note: string | null,
+  items: ApiWatchlistItem[]
+): ApiWatchlistItem {
+  const now = new Date().toISOString();
+  const groupKey = exchange ?? '';
+  const groupOrders = items
+    .filter((item) => getGroupKey(item) === groupKey)
+    .map((item) => item.sort_order)
+    .filter((sortOrder): sortOrder is number => typeof sortOrder === 'number');
+
+  return {
+    id: `watchlist-${symbol}`,
+    symbol,
+    exchange,
+    note,
+    sort_order: groupOrders.length > 0 ? Math.max(...groupOrders) + 1 : 0,
+    created_at: now,
+    updated_at: now
+  };
+}
+
+function toPricedItem(
+  item: ApiWatchlistItem,
+  priceData: ReturnType<typeof useWatchlistPrices>['pricesMap'][string] | undefined
+): WatchlistItemWithPrice {
+  return {
+    id: item.id,
+    userId: 'current-user',
+    symbol: item.symbol,
+    addedAt: new Date(item.created_at),
+    exchange: item.exchange,
+    note: item.note,
+    sort_order: item.sort_order,
+    currentPrice: priceData?.price,
+    change: priceData?.change,
+    changePercent: priceData?.changePercent,
+    lastUpdated: priceData?.lastUpdated
+  };
+}
+
 export function WatchlistCard() {
-  const [items, setItems] = useState<string[]>([]);
+  const [items, setItems] = useState<ApiWatchlistItem[]>([]);
   const [symbol, setSymbol] = useState('');
+  const [exchange, setExchange] = useState('');
+  const [note, setNote] = useState('');
   const [busy, setBusy] = useState(false);
+  const [reorderingSymbol, setReorderingSymbol] = useState<string | null>(null);
   const [initialLoading, setInitialLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);
   const [addError, setAddError] = useState<AddTickerError | null>(null);
-
+  const [editingItem, setEditingItem] = useState<ApiWatchlistItem | null>(null);
+  const [editExchange, setEditExchange] = useState('');
+  const [editNote, setEditNote] = useState('');
   const [retryCount, setRetryCount] = useState(0);
 
-  const { pricesMap, isLoading, errorSymbols } = useWatchlistPrices(items);
+  const symbols = useMemo(() => items.map((item) => item.symbol), [items]);
+  const sortedItems = useMemo(
+    () => [...items].sort(compareWatchlistItems),
+    [items]
+  );
+  const groupedItems = useMemo(() => {
+    const groups = new Map<string, ApiWatchlistItem[]>();
+
+    sortedItems.forEach((item) => {
+      const groupKey = getGroupKey(item);
+      groups.set(groupKey, [...(groups.get(groupKey) ?? []), item]);
+    });
+
+    return Array.from(groups.entries()).sort(([a], [b]) =>
+      compareGroupKeys(a, b)
+    );
+  }, [sortedItems]);
+
+  const { pricesMap, isLoading, errorSymbols } = useWatchlistPrices(symbols);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -77,11 +233,9 @@ export function WatchlistCard() {
             const json = await res.json();
 
             if (!controller.signal.aborted && json.success) {
-              setItems(json.data.watchlist);
-              span?.setAttribute?.(
-                'watchlist.count',
-                json.data.watchlist.length
-              );
+              const nextItems = getResponseItems(json);
+              setItems(nextItems);
+              span?.setAttribute?.('watchlist.count', nextItems.length);
             } else if (!controller.signal.aborted) {
               throw new Error(json.error?.message || 'Failed to load');
             }
@@ -101,13 +255,31 @@ export function WatchlistCard() {
     };
   }, [retryCount]);
 
-  async function mutate(action: 'add' | 'remove', sym: string) {
+  async function mutate(
+    action: 'add' | 'remove',
+    sym: string,
+    metadata: { exchange?: string | null; note?: string | null } = {}
+  ): Promise<WatchlistMutationResponse> {
     setBusy(true);
-    const optimistic = new Set(items);
-    if (action === 'add') optimistic.add(sym);
-    if (action === 'remove') optimistic.delete(sym);
     const prev = items;
-    setItems(Array.from(optimistic));
+
+    if (action === 'add') {
+      setItems((currentItems) => [
+        ...currentItems,
+        createOptimisticItem(
+          sym,
+          metadata.exchange ?? null,
+          metadata.note ?? null,
+          currentItems
+        )
+      ]);
+    }
+
+    if (action === 'remove') {
+      setItems((currentItems) =>
+        currentItems.filter((item) => item.symbol !== sym)
+      );
+    }
 
     try {
       const { res, json } = await runWithSpan(
@@ -118,7 +290,11 @@ export function WatchlistCard() {
           const response = await fetch('/api/watchlist', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ action, symbol: sym })
+            body: JSON.stringify({
+              action,
+              symbol: sym,
+              ...(action === 'add' ? metadata : {})
+            })
           });
           span?.setAttribute?.('http.status_code', response.status);
           const payload = await response.json();
@@ -129,20 +305,138 @@ export function WatchlistCard() {
         setItems(prev);
         toast.error('Failed to update watchlist');
         return {
-          ok: false as const,
+          ok: false,
           status: res.status,
           message: json?.error?.message || 'Request failed'
         };
       }
-      setItems(json.data.watchlist);
-      return { ok: true as const };
+      setItems(getResponseItems(json));
+      return { ok: true };
     } catch (error) {
       logger.error('Watchlist mutation failed', { error });
-      setItems(prev); // rollback
+      setItems(prev);
       toast.error('Failed to update watchlist');
-      return { ok: false as const, error };
+      return { ok: false, error };
     } finally {
       setBusy(false);
+    }
+  }
+
+  async function updateMetadata() {
+    if (!editingItem) return;
+    const normalizedExchange = normalizeExchangeInput(editExchange);
+    const normalizedNote = normalizeNoteInput(editNote);
+
+    if ((normalizedNote?.length ?? 0) > NOTE_MAX_LENGTH) {
+      toast.error('Note must be 500 characters or less');
+      return;
+    }
+
+    setBusy(true);
+    const prev = items;
+    const updatedAt = new Date().toISOString();
+    setItems((currentItems) =>
+      currentItems.map((item) =>
+        item.symbol === editingItem.symbol
+          ? {
+              ...item,
+              exchange: normalizedExchange,
+              note: normalizedNote,
+              updated_at: updatedAt
+            }
+          : item
+      )
+    );
+
+    try {
+      const response = await fetch('/api/watchlist', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'update',
+          symbol: editingItem.symbol,
+          exchange: normalizedExchange,
+          note: normalizedNote
+        })
+      });
+      const json = await response.json();
+
+      if (!response.ok || !json?.success) {
+        setItems(prev);
+        toast.error('Failed to update watchlist item');
+        return;
+      }
+
+      setItems(getResponseItems(json));
+      setEditingItem(null);
+    } catch (error) {
+      logger.error('Watchlist metadata update failed', { error });
+      setItems(prev);
+      toast.error('Failed to update watchlist item');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function reorderWithinGroup(symbolToMove: string, direction: -1 | 1) {
+    const currentItem = items.find((item) => item.symbol === symbolToMove);
+    if (!currentItem) return;
+
+    const groupKey = getGroupKey(currentItem);
+    const groupItems = sortedItems.filter((item) => getGroupKey(item) === groupKey);
+    const currentIndex = groupItems.findIndex(
+      (item) => item.symbol === symbolToMove
+    );
+    const nextIndex = currentIndex + direction;
+
+    if (currentIndex < 0 || nextIndex < 0 || nextIndex >= groupItems.length) {
+      return;
+    }
+
+    const reorderedGroup = [...groupItems];
+    const [movedItem] = reorderedGroup.splice(currentIndex, 1);
+    reorderedGroup.splice(nextIndex, 0, movedItem);
+
+    const orderBySymbol = new Map(
+      reorderedGroup.map((item, index) => [item.symbol, index])
+    );
+    const prev = items;
+    const nextItems = items.map((item) =>
+      orderBySymbol.has(item.symbol)
+        ? { ...item, sort_order: orderBySymbol.get(item.symbol)! }
+        : item
+    );
+
+    setReorderingSymbol(symbolToMove);
+    setItems(nextItems);
+
+    try {
+      const response = await fetch('/api/watchlist', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'reorder',
+          items: reorderedGroup.map((item, index) => ({
+            symbol: item.symbol,
+            sort_order: index
+          }))
+        })
+      });
+      const json = await response.json();
+
+      if (!response.ok || !json?.success) {
+        setItems(prev);
+        toast.error('Failed to reorder watchlist');
+        return;
+      }
+
+      setItems(getResponseItems(json));
+    } catch (error) {
+      logger.error('Watchlist reorder failed', { error });
+      setItems(prev);
+      toast.error('Failed to reorder watchlist');
+    } finally {
+      setReorderingSymbol(null);
     }
   }
 
@@ -171,7 +465,7 @@ export function WatchlistCard() {
       }
 
       const normalized = normalizeTicker(rawSymbol);
-      if (items.includes(normalized)) {
+      if (items.some((item) => item.symbol === normalized)) {
         const mapped = getAddTickerError({ type: 'duplicate' });
         setAddError(mapped);
         logger.info('Add ticker duplicate prevented', {
@@ -181,7 +475,16 @@ export function WatchlistCard() {
         return;
       }
 
-      const response = await mutate('add', normalized);
+      const normalizedNote = normalizeNoteInput(note);
+      if ((normalizedNote?.length ?? 0) > NOTE_MAX_LENGTH) {
+        toast.error('Note must be 500 characters or less');
+        return;
+      }
+
+      const response = await mutate('add', normalized, {
+        exchange: normalizeExchangeInput(exchange),
+        note: normalizedNote
+      });
       if (!response.ok) {
         const mapped = response.status
           ? getAddTickerError({
@@ -200,8 +503,19 @@ export function WatchlistCard() {
       }
 
       setSymbol('');
+      setExchange('');
+      setNote('');
     });
   };
+
+  function openEditDialog(item: WatchlistItemWithPrice) {
+    const sourceItem = items.find((candidate) => candidate.symbol === item.symbol);
+    if (!sourceItem) return;
+
+    setEditingItem(sourceItem);
+    setEditExchange(sourceItem.exchange ?? '');
+    setEditNote(sourceItem.note ?? '');
+  }
 
   return (
     <Card>
@@ -209,7 +523,7 @@ export function WatchlistCard() {
         <CardTitle>Watchlist</CardTitle>
       </CardHeader>
       <CardContent>
-        <form onSubmit={onAdd} className='mb-3 flex gap-2'>
+        <form onSubmit={onAdd} className='mb-4 grid gap-2 sm:grid-cols-4'>
           <Input
             placeholder='Add symbol (1-5 letters, e.g., MSFT)'
             value={symbol}
@@ -217,11 +531,23 @@ export function WatchlistCard() {
               setSymbol(e.target.value.toUpperCase());
               if (addError) setAddError(null);
             }}
-            className='w-40'
+            className='sm:col-span-2'
+          />
+          <Input
+            placeholder='Exchange'
+            value={exchange}
+            onChange={(e) => setExchange(e.target.value.toUpperCase())}
           />
           <Button type='submit' disabled={busy}>
             Add
           </Button>
+          <Textarea
+            placeholder='Note'
+            value={note}
+            maxLength={NOTE_MAX_LENGTH}
+            onChange={(e) => setNote(e.target.value)}
+            className='min-h-10 resize-none sm:col-span-4'
+          />
         </form>
         {initialLoading ? (
           <LoadingSkeleton count={3} />
@@ -247,37 +573,43 @@ export function WatchlistCard() {
         ) : isLoading && Object.keys(pricesMap).length === 0 ? (
           <LoadingSkeleton count={items.length} />
         ) : (
-          <div className='space-y-2'>
-            {items.map((symbol) => {
-              const priceData = pricesMap[symbol];
-              const hasError = errorSymbols.includes(symbol);
-              const isItemLoading = isLoading && !priceData && !hasError;
+          <div className='space-y-4'>
+            {groupedItems.map(([groupKey, groupItems]) => (
+              <section key={groupKey || 'ungrouped'} className='space-y-2'>
+                <h3 className='text-muted-foreground text-xs font-semibold tracking-normal'>
+                  {getGroupLabel(groupKey)}
+                </h3>
+                <div className='space-y-2'>
+                  {groupItems.map((item, index) => {
+                    const symbol = item.symbol;
+                    const priceData = pricesMap[symbol];
+                    const hasError = errorSymbols.includes(symbol);
+                    const isItemLoading = isLoading && !priceData && !hasError;
+                    const watchlistItem = toPricedItem(item, priceData);
 
-              const watchlistItem: WatchlistItemWithPrice = {
-                id: `watchlist-${symbol}`,
-                userId: 'current-user',
-                symbol,
-                addedAt: new Date(),
-                currentPrice: priceData?.price,
-                change: priceData?.change,
-                changePercent: priceData?.changePercent,
-                lastUpdated: priceData?.lastUpdated
-              };
-
-              return (
-                <WatchlistItemDisplay
-                  key={symbol}
-                  item={watchlistItem}
-                  onRemove={(sym) => mutate('remove', sym)}
-                  onClick={(sym) =>
-                    useDashboardStore.getState().setSelectedTicker(sym)
-                  }
-                  isLoading={isItemLoading}
-                  isRemoving={busy}
-                  error={hasError ? 'Failed to load price' : null}
-                />
-              );
-            })}
+                    return (
+                      <WatchlistItemDisplay
+                        key={item.id}
+                        item={watchlistItem}
+                        onRemove={(sym) => mutate('remove', sym)}
+                        onEdit={openEditDialog}
+                        onMoveUp={(sym) => reorderWithinGroup(sym, -1)}
+                        onMoveDown={(sym) => reorderWithinGroup(sym, 1)}
+                        onClick={(sym) =>
+                          useDashboardStore.getState().setSelectedTicker(sym)
+                        }
+                        isLoading={isItemLoading}
+                        isRemoving={busy}
+                        isReordering={reorderingSymbol === symbol}
+                        canMoveUp={index > 0}
+                        canMoveDown={index < groupItems.length - 1}
+                        error={hasError ? 'Failed to load price' : null}
+                      />
+                    );
+                  })}
+                </div>
+              </section>
+            ))}
           </div>
         )}
         {addError ? (
@@ -290,6 +622,60 @@ export function WatchlistCard() {
           />
         ) : null}
       </CardContent>
+      <Dialog
+        open={Boolean(editingItem)}
+        onOpenChange={(open) => {
+          if (!open) setEditingItem(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              Edit {editingItem ? editingItem.symbol : 'watchlist item'}
+            </DialogTitle>
+            <DialogDescription>
+              Update the exchange group and research note.
+            </DialogDescription>
+          </DialogHeader>
+          <form
+            className='space-y-4'
+            onSubmit={(event) => {
+              event.preventDefault();
+              updateMetadata();
+            }}
+          >
+            <div className='space-y-2'>
+              <Label htmlFor='watchlist-edit-exchange'>Exchange</Label>
+              <Input
+                id='watchlist-edit-exchange'
+                value={editExchange}
+                onChange={(e) => setEditExchange(e.target.value.toUpperCase())}
+                placeholder='Exchange'
+              />
+            </div>
+            <div className='space-y-2'>
+              <Label htmlFor='watchlist-edit-note'>Note</Label>
+              <Textarea
+                id='watchlist-edit-note'
+                value={editNote}
+                maxLength={NOTE_MAX_LENGTH}
+                onChange={(e) => setEditNote(e.target.value)}
+                placeholder='Note'
+              />
+            </div>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button type='button' variant='outline'>
+                  Cancel
+                </Button>
+              </DialogClose>
+              <Button type='submit' disabled={busy}>
+                Save
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
     </Card>
   );
 }

--- a/src/features/stock-dashboard/components/WatchlistItemDisplay.tsx
+++ b/src/features/stock-dashboard/components/WatchlistItemDisplay.tsx
@@ -1,17 +1,36 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from '@/components/ui/tooltip';
 import { PriceIndicator } from './PriceIndicator';
 import { WatchlistItemWithPrice } from '@/types/stocks';
-import { Loader2, AlertCircle } from 'lucide-react';
+import {
+  AlertCircle,
+  ArrowDown,
+  ArrowUp,
+  Loader2,
+  Pencil,
+  Trash2
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface WatchlistItemDisplayProps {
   item: WatchlistItemWithPrice;
   onRemove: (symbol: string) => void;
+  onEdit?: (item: WatchlistItemWithPrice) => void;
+  onMoveUp?: (symbol: string) => void;
+  onMoveDown?: (symbol: string) => void;
   onClick?: (symbol: string) => void;
   isLoading?: boolean;
   isRemoving?: boolean;
+  isReordering?: boolean;
+  canMoveUp?: boolean;
+  canMoveDown?: boolean;
   error?: string | null;
   className?: string;
 }
@@ -19,9 +38,15 @@ interface WatchlistItemDisplayProps {
 export function WatchlistItemDisplay({
   item,
   onRemove,
+  onEdit,
+  onMoveUp,
+  onMoveDown,
   onClick,
   isLoading = false,
   isRemoving = false,
+  isReordering = false,
+  canMoveUp = false,
+  canMoveDown = false,
   error,
   className
 }: WatchlistItemDisplayProps) {
@@ -35,17 +60,40 @@ export function WatchlistItemDisplay({
     onRemove(item.symbol);
   };
 
+  const handleEdit = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onEdit?.(item);
+  };
+
+  const handleMoveUp = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onMoveUp?.(item.symbol);
+  };
+
+  const handleMoveDown = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onMoveDown?.(item.symbol);
+  };
+
   return (
     <div
       onClick={() => onClick?.(item.symbol)}
       className={cn(
-        'bg-card flex items-center justify-between rounded-lg border p-3',
+        'bg-card flex items-start justify-between gap-3 rounded-lg border p-3',
         onClick && 'hover:bg-accent/50 cursor-pointer transition-colors',
         className
       )}
     >
-      <div className='flex items-center space-x-3'>
-        <div className='text-base font-medium'>{item.symbol}</div>
+      <div className='min-w-0 flex-1 space-y-1'>
+        <div className='flex min-w-0 flex-wrap items-center gap-2'>
+          <div className='text-base font-medium'>{item.symbol}</div>
+          {item.exchange ? <Badge variant='outline'>{item.exchange}</Badge> : null}
+          {item.note ? (
+            <div className='text-muted-foreground max-w-full truncate text-xs'>
+              {item.note}
+            </div>
+          ) : null}
+        </div>
 
         {isLoading ? (
           <div className='text-muted-foreground flex items-center space-x-2'>
@@ -71,22 +119,77 @@ export function WatchlistItemDisplay({
         )}
       </div>
 
-      <Button
-        variant='outline'
-        size='sm'
-        disabled={isRemoving}
-        onClick={handleRemove}
-        className='ml-4'
-      >
-        {isRemoving ? (
-          <>
-            <Loader2 className='mr-1 h-3 w-3 animate-spin' />
-            Removing
-          </>
-        ) : (
-          'Remove'
-        )}
-      </Button>
+      <div className='flex shrink-0 items-center gap-1'>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type='button'
+              variant='ghost'
+              size='icon'
+              disabled={!canMoveUp || isReordering}
+              onClick={handleMoveUp}
+              aria-label={`Move ${item.symbol} up`}
+              className='size-8'
+            >
+              <ArrowUp className='h-4 w-4' />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Move up</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type='button'
+              variant='ghost'
+              size='icon'
+              disabled={!canMoveDown || isReordering}
+              onClick={handleMoveDown}
+              aria-label={`Move ${item.symbol} down`}
+              className='size-8'
+            >
+              <ArrowDown className='h-4 w-4' />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Move down</TooltipContent>
+        </Tooltip>
+        {onEdit ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type='button'
+                variant='ghost'
+                size='icon'
+                onClick={handleEdit}
+                aria-label={`Edit ${item.symbol}`}
+                className='size-8'
+              >
+                <Pencil className='h-4 w-4' />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Edit metadata</TooltipContent>
+          </Tooltip>
+        ) : null}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type='button'
+              variant='ghost'
+              size='icon'
+              disabled={isRemoving}
+              onClick={handleRemove}
+              aria-label={`Remove ${item.symbol}`}
+              className='size-8'
+            >
+              {isRemoving ? (
+                <Loader2 className='h-4 w-4 animate-spin' />
+              ) : (
+                <Trash2 className='h-4 w-4' />
+              )}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Remove</TooltipContent>
+        </Tooltip>
+      </div>
     </div>
   );
 }

--- a/src/features/stock-dashboard/components/__tests__/WatchlistCard.integration.test.tsx
+++ b/src/features/stock-dashboard/components/__tests__/WatchlistCard.integration.test.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { WatchlistCard } from '../WatchlistCard';
+import type { WatchlistItem } from '@/types/watchlist';
 
 // Mock fetch
 const originalFetch = global.fetch;
@@ -25,6 +26,30 @@ function renderWithProviders(ui: React.ReactElement) {
   );
 }
 
+function createItem(symbol: string): WatchlistItem {
+  return {
+    id: `item-${symbol}`,
+    symbol,
+    exchange: null,
+    note: null,
+    sort_order: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z'
+  };
+}
+
+function watchlistResponse(symbols: string[]) {
+  const items = symbols.map(createItem);
+
+  return {
+    success: true,
+    data: {
+      watchlist: symbols,
+      items
+    }
+  };
+}
+
 describe('WatchlistCard Persistence Integration', () => {
   test('loads watchlist from API on mount', async () => {
     (global.fetch as jest.Mock).mockImplementation((url) => {
@@ -32,10 +57,7 @@ describe('WatchlistCard Persistence Integration', () => {
         return Promise.resolve({
           ok: true,
           json: () =>
-            Promise.resolve({
-              success: true,
-              data: { watchlist: ['MSFT', 'GOOGL'] }
-            })
+            Promise.resolve(watchlistResponse(['MSFT', 'GOOGL']))
         });
       }
       if (typeof url === 'string' && url.includes('/api/stocks/quote/')) {
@@ -54,7 +76,10 @@ describe('WatchlistCard Persistence Integration', () => {
     renderWithProviders(<WatchlistCard />);
 
     // Should call GET /api/watchlist
-    expect(global.fetch).toHaveBeenCalledWith('/api/watchlist');
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/watchlist',
+      expect.objectContaining({ signal: expect.any(Object) })
+    );
 
     // Should display loaded symbols
     await waitFor(() => {
@@ -70,7 +95,7 @@ describe('WatchlistCard Persistence Integration', () => {
           return Promise.resolve({
             ok: true,
             json: () =>
-              Promise.resolve({ success: true, data: { watchlist: ['MSFT'] } })
+              Promise.resolve(watchlistResponse(['MSFT']))
           });
         }
         if (init.method === 'POST') {
@@ -79,7 +104,7 @@ describe('WatchlistCard Persistence Integration', () => {
             return Promise.resolve({
               ok: true,
               json: () =>
-                Promise.resolve({ success: true, data: { watchlist: [] } })
+                Promise.resolve(watchlistResponse([]))
             });
           }
         }

--- a/src/features/stock-dashboard/components/__tests__/watchlist-card.test.tsx
+++ b/src/features/stock-dashboard/components/__tests__/watchlist-card.test.tsx
@@ -3,9 +3,10 @@
  */
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { WatchlistCard } from '../WatchlistCard';
+import type { WatchlistItem } from '@/types/watchlist';
 
 function renderWithProviders(ui: React.ReactElement) {
   const queryClient = new QueryClient({
@@ -15,6 +16,41 @@ function renderWithProviders(ui: React.ReactElement) {
     <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
   );
   return { ...utils, queryClient };
+}
+
+function createItem(overrides: Partial<WatchlistItem>): WatchlistItem {
+  return {
+    id: 'item-1',
+    symbol: 'AAPL',
+    exchange: null,
+    note: null,
+    sort_order: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides
+  };
+}
+
+function watchlistResponse(items: WatchlistItem[]) {
+  return {
+    success: true,
+    data: {
+      watchlist: items.map((item) => item.symbol),
+      items
+    }
+  };
+}
+
+function quoteResponse() {
+  return {
+    success: true,
+    data: {
+      price: 100,
+      change: 1,
+      changePercent: 1,
+      lastUpdated: '2026-01-01T00:00:00.000Z'
+    }
+  };
 }
 
 describe('WatchlistCard initial load', () => {
@@ -32,15 +68,17 @@ describe('WatchlistCard initial load', () => {
   test('fetches watchlist from API on mount', async () => {
     (global.fetch as jest.Mock).mockResolvedValue({
       ok: true,
-      json: async () => ({
-        success: true,
-        data: { watchlist: ['AAPL'] }
-      })
+      json: async () => watchlistResponse([createItem({ symbol: 'AAPL' })])
     });
 
     renderWithProviders(<WatchlistCard />);
 
-    expect(global.fetch).toHaveBeenCalledWith('/api/watchlist');
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/watchlist',
+        expect.objectContaining({ signal: expect.any(Object) })
+      );
+    });
   });
 
   test('shows error message if load fails', async () => {
@@ -71,11 +109,10 @@ describe('WatchlistCard add error modal flows', () => {
 
   test('shows validation modal and preserves input for invalid symbol', async () => {
     global.fetch = jest.fn((url) => {
-      // Handle initial load
       if (typeof url === 'string' && url.endsWith('/api/watchlist')) {
         return Promise.resolve({
           ok: true,
-          json: async () => ({ success: true, data: { watchlist: [] } })
+          json: async () => watchlistResponse([])
         });
       }
       return Promise.resolve({ ok: true });
@@ -84,9 +121,11 @@ describe('WatchlistCard add error modal flows', () => {
     const user = userEvent.setup();
     renderWithProviders(<WatchlistCard />);
 
-    // Wait for initial load
     await waitFor(() =>
-      expect(global.fetch).toHaveBeenCalledWith('/api/watchlist')
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/watchlist',
+        expect.objectContaining({ signal: expect.any(Object) })
+      )
     );
     (global.fetch as jest.Mock).mockClear();
 
@@ -105,7 +144,7 @@ describe('WatchlistCard add error modal flows', () => {
   });
 
   test('shows duplicate modal and does not re-add the symbol', async () => {
-    const watchlist: string[] = [];
+    const watchlist: WatchlistItem[] = [];
     let addCalls = 0;
 
     global.fetch = jest.fn(
@@ -115,40 +154,30 @@ describe('WatchlistCard add error modal flows', () => {
           if (!init || !init.method || init.method === 'GET') {
             return {
               ok: true,
-              json: async () => ({
-                success: true,
-                data: { watchlist: [...watchlist] }
-              })
+              json: async () => watchlistResponse(watchlist)
             } as any;
           }
           const body = init?.body ? JSON.parse(String(init.body)) : {};
           if (body.action === 'add') {
             addCalls += 1;
-            if (!watchlist.includes(body.symbol)) watchlist.push(body.symbol);
+            if (!watchlist.some((item) => item.symbol === body.symbol)) {
+              watchlist.push(createItem({ symbol: body.symbol }));
+            }
           } else if (body.action === 'remove') {
-            const idx = watchlist.indexOf(body.symbol);
+            const idx = watchlist.findIndex(
+              (item) => item.symbol === body.symbol
+            );
             if (idx >= 0) watchlist.splice(idx, 1);
           }
           return {
             ok: true,
-            json: async () => ({
-              success: true,
-              data: { watchlist: [...watchlist] }
-            })
+            json: async () => watchlistResponse(watchlist)
           } as any;
         }
         if (url.includes('/api/stocks/quote/')) {
           return {
             ok: true,
-            json: async () => ({
-              success: true,
-              data: {
-                price: 100,
-                change: 1,
-                changePercent: 1,
-                lastUpdated: '2023-01-01T00:00:00.000Z'
-              }
-            })
+            json: async () => quoteResponse()
           } as any;
         }
         throw new Error('Unexpected URL ' + url);
@@ -216,8 +245,14 @@ describe('WatchlistCard add error modal flows', () => {
   });
 
   test('shows network modal when the request fails', async () => {
-    global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+    global.fetch = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
+      if (url.endsWith('/api/watchlist') && (!init || !init.method)) {
+        return {
+          ok: true,
+          json: async () => watchlistResponse([])
+        } as any;
+      }
       if (url.endsWith('/api/watchlist')) {
         throw new Error('Network down');
       }
@@ -239,36 +274,259 @@ describe('WatchlistCard add error modal flows', () => {
     ).toBeInTheDocument();
     expect(input).toHaveValue('TSLA');
   });
+});
 
-  test('shows unknown modal for unexpected server errors', async () => {
+describe('WatchlistCard groups and metadata', () => {
+  const originalFetch = global.fetch as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn() as any;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  test('renders exchange groups with notes and sorted rows', async () => {
+    const items = [
+      createItem({
+        id: 'item-msft',
+        symbol: 'MSFT',
+        exchange: 'NASDAQ',
+        note: 'Cloud',
+        sort_order: 1
+      }),
+      createItem({
+        id: 'item-rio',
+        symbol: 'RIO',
+        exchange: null,
+        note: 'Materials',
+        sort_order: 0
+      }),
+      createItem({
+        id: 'item-aapl',
+        symbol: 'AAPL',
+        exchange: 'NASDAQ',
+        note: 'Core',
+        sort_order: 0
+      })
+    ];
+
     global.fetch = jest.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url.endsWith('/api/watchlist')) {
         return {
-          ok: false,
-          status: 500,
-          json: async () => ({
-            success: false,
-            error: { message: 'Unexpected server error' }
-          })
+          ok: true,
+          json: async () => watchlistResponse(items)
+        } as any;
+      }
+      if (url.includes('/api/stocks/quote/')) {
+        return {
+          ok: true,
+          json: async () => quoteResponse()
         } as any;
       }
       throw new Error('Unexpected URL ' + url);
     }) as any;
 
+    renderWithProviders(<WatchlistCard />);
+
+    expect(
+      await screen.findByRole('heading', { name: 'NASDAQ' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Ungrouped' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Core')).toBeInTheDocument();
+    expect(screen.getByText('Cloud')).toBeInTheDocument();
+
+    const symbols = screen
+      .getAllByText(/^(AAPL|MSFT|RIO)$/)
+      .map((node) => node.textContent);
+    expect(symbols).toEqual(['AAPL', 'MSFT', 'RIO']);
+  });
+
+  test('adds a symbol with exchange and note metadata', async () => {
+    let postBody: any = null;
+    const nextItems = [
+      createItem({
+        symbol: 'AAPL',
+        exchange: 'NASDAQ',
+        note: 'Core holding'
+      })
+    ];
+
+    global.fetch = jest.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith('/api/watchlist') && (!init || !init.method)) {
+          return {
+            ok: true,
+            json: async () => watchlistResponse([])
+          } as any;
+        }
+        if (url.endsWith('/api/watchlist') && init?.method === 'POST') {
+          postBody = JSON.parse(String(init.body));
+          return {
+            ok: true,
+            json: async () => watchlistResponse(nextItems)
+          } as any;
+        }
+        if (url.includes('/api/stocks/quote/')) {
+          return {
+            ok: true,
+            json: async () => quoteResponse()
+          } as any;
+        }
+        throw new Error('Unexpected URL ' + url);
+      }
+    ) as any;
+
     const user = userEvent.setup();
     renderWithProviders(<WatchlistCard />);
 
-    const input = screen.getByPlaceholderText(
-      'Add symbol (1-5 letters, e.g., MSFT)'
+    await screen.findByText('No symbols yet.');
+    await user.type(
+      screen.getByPlaceholderText('Add symbol (1-5 letters, e.g., MSFT)'),
+      'aapl'
     );
-    await user.type(input, 'IBM');
+    await user.type(screen.getByPlaceholderText('Exchange'), 'nasdaq');
+    await user.type(screen.getByPlaceholderText('Note'), 'Core holding');
     await user.click(screen.getByRole('button', { name: /add/i }));
 
-    expect(await screen.findByText('Something went wrong')).toBeInTheDocument();
-    expect(
-      screen.getByText('We could not add that symbol.')
-    ).toBeInTheDocument();
-    expect(input).toHaveValue('IBM');
+    await waitFor(() =>
+      expect(postBody).toEqual({
+        action: 'add',
+        symbol: 'AAPL',
+        exchange: 'NASDAQ',
+        note: 'Core holding'
+      })
+    );
+  });
+
+  test('edits existing item metadata', async () => {
+    let patchBody: any = null;
+    const initialItems = [createItem({ symbol: 'AAPL', exchange: 'NASDAQ' })];
+    const updatedItems = [
+      createItem({
+        symbol: 'AAPL',
+        exchange: 'NYSE',
+        note: 'Dividend watch'
+      })
+    ];
+
+    global.fetch = jest.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith('/api/watchlist') && (!init || !init.method)) {
+          return {
+            ok: true,
+            json: async () => watchlistResponse(initialItems)
+          } as any;
+        }
+        if (url.endsWith('/api/watchlist') && init?.method === 'PATCH') {
+          patchBody = JSON.parse(String(init.body));
+          return {
+            ok: true,
+            json: async () => watchlistResponse(updatedItems)
+          } as any;
+        }
+        if (url.includes('/api/stocks/quote/')) {
+          return {
+            ok: true,
+            json: async () => quoteResponse()
+          } as any;
+        }
+        throw new Error('Unexpected URL ' + url);
+      }
+    ) as any;
+
+    const user = userEvent.setup();
+    renderWithProviders(<WatchlistCard />);
+
+    await screen.findByText('AAPL');
+    await user.click(screen.getByRole('button', { name: /edit aapl/i }));
+
+    const dialog = screen.getByRole('dialog');
+    const exchangeInput = within(dialog).getByLabelText('Exchange');
+    const noteInput = within(dialog).getByLabelText('Note');
+    await user.clear(exchangeInput);
+    await user.type(exchangeInput, 'nyse');
+    await user.type(noteInput, 'Dividend watch');
+    await user.click(within(dialog).getByRole('button', { name: /save/i }));
+
+    await waitFor(() =>
+      expect(patchBody).toEqual({
+        action: 'update',
+        symbol: 'AAPL',
+        exchange: 'NYSE',
+        note: 'Dividend watch'
+      })
+    );
+  });
+
+  test('reorders rows inside an exchange group', async () => {
+    let patchBody: any = null;
+    const initialItems = [
+      createItem({
+        id: 'item-aapl',
+        symbol: 'AAPL',
+        exchange: 'NASDAQ',
+        sort_order: 0
+      }),
+      createItem({
+        id: 'item-msft',
+        symbol: 'MSFT',
+        exchange: 'NASDAQ',
+        sort_order: 1
+      })
+    ];
+    const reorderedItems = [
+      { ...initialItems[1], sort_order: 0 },
+      { ...initialItems[0], sort_order: 1 }
+    ];
+
+    global.fetch = jest.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith('/api/watchlist') && (!init || !init.method)) {
+          return {
+            ok: true,
+            json: async () => watchlistResponse(initialItems)
+          } as any;
+        }
+        if (url.endsWith('/api/watchlist') && init?.method === 'PATCH') {
+          patchBody = JSON.parse(String(init.body));
+          return {
+            ok: true,
+            json: async () => watchlistResponse(reorderedItems)
+          } as any;
+        }
+        if (url.includes('/api/stocks/quote/')) {
+          return {
+            ok: true,
+            json: async () => quoteResponse()
+          } as any;
+        }
+        throw new Error('Unexpected URL ' + url);
+      }
+    ) as any;
+
+    const user = userEvent.setup();
+    renderWithProviders(<WatchlistCard />);
+
+    await screen.findByText('MSFT');
+    await user.click(screen.getByRole('button', { name: /move msft up/i }));
+
+    await waitFor(() =>
+      expect(patchBody).toEqual({
+        action: 'reorder',
+        items: [
+          { symbol: 'MSFT', sort_order: 0 },
+          { symbol: 'AAPL', sort_order: 1 }
+        ]
+      })
+    );
   });
 });

--- a/src/lib/watchlist/storage.test.ts
+++ b/src/lib/watchlist/storage.test.ts
@@ -1,0 +1,180 @@
+/**
+ * @jest-environment node
+ */
+import {
+  addToWatchlist,
+  getWatchlist,
+  getWatchlistItems,
+  reorderWatchlistItems,
+  updateWatchlistItemMetadata
+} from './storage';
+import { createClient } from '../supabase/server';
+import type { WatchlistItem } from '@/types/watchlist';
+
+jest.mock('../supabase/server', () => ({
+  createClient: jest.fn()
+}));
+
+function createItem(overrides: Partial<WatchlistItem>): WatchlistItem {
+  return {
+    id: 'item-1',
+    symbol: 'AAPL',
+    exchange: null,
+    note: null,
+    sort_order: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides
+  };
+}
+
+function createQuery(result: unknown) {
+  const query: any = {
+    select: jest.fn(() => query),
+    eq: jest.fn(() => query),
+    order: jest.fn(() => query),
+    delete: jest.fn(() => query),
+    update: jest.fn(() => query),
+    upsert: jest.fn(() => Promise.resolve(result)),
+    then: (resolve: (value: unknown) => unknown, reject: (reason: unknown) => unknown) =>
+      Promise.resolve(result).then(resolve, reject)
+  };
+
+  return query;
+}
+
+function createSupabase(...queries: any[]) {
+  const from = jest.fn();
+
+  queries.forEach((query) => from.mockReturnValueOnce(query));
+  from.mockReturnValue(queries[queries.length - 1]);
+
+  return { from };
+}
+
+describe('watchlist storage', () => {
+  const mockCreateClient = createClient as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('fetches watchlist items with metadata ordering', async () => {
+    const items = [
+      createItem({ symbol: 'AAPL', exchange: 'NASDAQ', sort_order: 0 }),
+      createItem({ id: 'item-2', symbol: 'MSFT', exchange: 'NASDAQ' })
+    ];
+    const query = createQuery({ data: items, error: null });
+    const supabase = createSupabase(query);
+
+    mockCreateClient.mockResolvedValue(supabase);
+
+    await expect(getWatchlistItems('user_123')).resolves.toEqual(items);
+    expect(supabase.from).toHaveBeenCalledWith('stock_watchlist_items');
+    expect(query.select).toHaveBeenCalledWith(
+      'id,symbol,exchange,note,sort_order,created_at,updated_at'
+    );
+    expect(query.eq).toHaveBeenCalledWith('clerk_user_id', 'user_123');
+    expect(query.order).toHaveBeenNthCalledWith(1, 'exchange', {
+      ascending: true,
+      nullsFirst: false
+    });
+    expect(query.order).toHaveBeenNthCalledWith(2, 'sort_order', {
+      ascending: true,
+      nullsFirst: false
+    });
+    expect(query.order).toHaveBeenNthCalledWith(3, 'created_at', {
+      ascending: true
+    });
+  });
+
+  it('keeps a symbol-only getter for compatibility', async () => {
+    const items = [
+      createItem({ symbol: 'AAPL' }),
+      createItem({ id: 'item-2', symbol: 'MSFT' })
+    ];
+    const query = createQuery({ data: items, error: null });
+
+    mockCreateClient.mockResolvedValue(createSupabase(query));
+
+    await expect(getWatchlist('user_123')).resolves.toEqual(['AAPL', 'MSFT']);
+  });
+
+  it('adds symbols with normalized symbol and metadata', async () => {
+    const items = [
+      createItem({ symbol: 'AAPL', exchange: 'NASDAQ', note: 'Core' })
+    ];
+    const upsertQuery = createQuery({ error: null });
+    const fetchQuery = createQuery({ data: items, error: null });
+
+    mockCreateClient
+      .mockResolvedValueOnce(createSupabase(upsertQuery))
+      .mockResolvedValueOnce(createSupabase(fetchQuery));
+
+    await expect(
+      addToWatchlist('user_123', 'aapl', {
+        exchange: 'NASDAQ',
+        note: 'Core'
+      })
+    ).resolves.toEqual(items);
+
+    expect(upsertQuery.upsert).toHaveBeenCalledWith(
+      {
+        clerk_user_id: 'user_123',
+        symbol: 'AAPL',
+        exchange: 'NASDAQ',
+        note: 'Core'
+      },
+      { onConflict: 'clerk_user_id,symbol', ignoreDuplicates: true }
+    );
+  });
+
+  it('updates item metadata', async () => {
+    const items = [createItem({ symbol: 'AAPL', exchange: 'NYSE' })];
+    const updateQuery = createQuery({ error: null });
+    const fetchQuery = createQuery({ data: items, error: null });
+
+    mockCreateClient
+      .mockResolvedValueOnce(createSupabase(updateQuery))
+      .mockResolvedValueOnce(createSupabase(fetchQuery));
+
+    await expect(
+      updateWatchlistItemMetadata('user_123', 'aapl', {
+        exchange: 'NYSE',
+        note: null
+      })
+    ).resolves.toEqual(items);
+
+    expect(updateQuery.update).toHaveBeenCalledWith({
+      exchange: 'NYSE',
+      note: null
+    });
+    expect(updateQuery.eq).toHaveBeenCalledWith('symbol', 'AAPL');
+  });
+
+  it('persists sort orders for reorder operations', async () => {
+    const items = [
+      createItem({ symbol: 'MSFT', sort_order: 0 }),
+      createItem({ symbol: 'AAPL', sort_order: 1 })
+    ];
+    const updateMsftQuery = createQuery({ error: null });
+    const updateAaplQuery = createQuery({ error: null });
+    const fetchQuery = createQuery({ data: items, error: null });
+
+    mockCreateClient
+      .mockResolvedValueOnce(createSupabase(updateMsftQuery, updateAaplQuery))
+      .mockResolvedValueOnce(createSupabase(fetchQuery));
+
+    await expect(
+      reorderWatchlistItems('user_123', [
+        { symbol: 'msft', sort_order: 0 },
+        { symbol: 'aapl', sort_order: 1 }
+      ])
+    ).resolves.toEqual(items);
+
+    expect(updateMsftQuery.update).toHaveBeenCalledWith({ sort_order: 0 });
+    expect(updateMsftQuery.eq).toHaveBeenCalledWith('symbol', 'MSFT');
+    expect(updateAaplQuery.update).toHaveBeenCalledWith({ sort_order: 1 });
+    expect(updateAaplQuery.eq).toHaveBeenCalledWith('symbol', 'AAPL');
+  });
+});

--- a/src/lib/watchlist/storage.ts
+++ b/src/lib/watchlist/storage.ts
@@ -1,4 +1,15 @@
 import { createClient } from '../supabase/server';
+import type { WatchlistItem } from '@/types/watchlist';
+
+export interface WatchlistItemMetadata {
+  exchange?: string | null;
+  note?: string | null;
+}
+
+export interface WatchlistReorderItem {
+  symbol: string;
+  sort_order: number;
+}
 
 export class WatchlistStorageError extends Error {
   constructor(
@@ -10,23 +21,38 @@ export class WatchlistStorageError extends Error {
   }
 }
 
+function toSymbolList(items: WatchlistItem[]): string[] {
+  return items.map((item) => item.symbol);
+}
+
 /**
- * Fetches the watchlist symbols for a specific user.
+ * Fetches full watchlist rows for a specific user.
  */
-export async function getWatchlist(userId: string): Promise<string[]> {
+export async function getWatchlistItems(
+  userId: string
+): Promise<WatchlistItem[]> {
   const supabase = await createClient();
 
   const { data, error } = await supabase
     .from('stock_watchlist_items')
-    .select('symbol')
+    .select('id,symbol,exchange,note,sort_order,created_at,updated_at')
     .eq('clerk_user_id', userId)
+    .order('exchange', { ascending: true, nullsFirst: false })
+    .order('sort_order', { ascending: true, nullsFirst: false })
     .order('created_at', { ascending: true });
 
   if (error) {
     throw new WatchlistStorageError('Failed to fetch watchlist', error);
   }
 
-  return data.map((item: { symbol: string }) => item.symbol);
+  return (data ?? []) as WatchlistItem[];
+}
+
+/**
+ * Fetches the watchlist symbols for a specific user.
+ */
+export async function getWatchlist(userId: string): Promise<string[]> {
+  return toSymbolList(await getWatchlistItems(userId));
 }
 
 /**
@@ -36,15 +62,21 @@ export async function getWatchlist(userId: string): Promise<string[]> {
  */
 export async function addToWatchlist(
   userId: string,
-  symbol: string
-): Promise<string[]> {
+  symbol: string,
+  metadata: WatchlistItemMetadata = {}
+): Promise<WatchlistItem[]> {
   const supabase = await createClient();
 
   // "ignoreDuplicates" might verify the unique constraint on (clerk_user_id, symbol)
   const { error } = await supabase
     .from('stock_watchlist_items')
     .upsert(
-      { clerk_user_id: userId, symbol: symbol.toUpperCase() },
+      {
+        clerk_user_id: userId,
+        symbol: symbol.toUpperCase(),
+        exchange: metadata.exchange ?? null,
+        note: metadata.note ?? null
+      },
       { onConflict: 'clerk_user_id,symbol', ignoreDuplicates: true }
     );
 
@@ -52,7 +84,7 @@ export async function addToWatchlist(
     throw new WatchlistStorageError('Failed to add to watchlist', error);
   }
 
-  return getWatchlist(userId);
+  return getWatchlistItems(userId);
 }
 
 /**
@@ -62,7 +94,7 @@ export async function addToWatchlist(
 export async function removeFromWatchlist(
   userId: string,
   symbol: string
-): Promise<string[]> {
+): Promise<WatchlistItem[]> {
   const supabase = await createClient();
 
   const { error } = await supabase
@@ -75,5 +107,57 @@ export async function removeFromWatchlist(
     throw new WatchlistStorageError('Failed to remove from watchlist', error);
   }
 
-  return getWatchlist(userId);
+  return getWatchlistItems(userId);
+}
+
+/**
+ * Updates exchange/note metadata for an existing watchlist item.
+ * Returns the updated list of watchlist rows.
+ */
+export async function updateWatchlistItemMetadata(
+  userId: string,
+  symbol: string,
+  metadata: WatchlistItemMetadata
+): Promise<WatchlistItem[]> {
+  const supabase = await createClient();
+
+  const { error } = await supabase
+    .from('stock_watchlist_items')
+    .update({
+      exchange: metadata.exchange ?? null,
+      note: metadata.note ?? null
+    })
+    .eq('clerk_user_id', userId)
+    .eq('symbol', symbol.toUpperCase());
+
+  if (error) {
+    throw new WatchlistStorageError('Failed to update watchlist item', error);
+  }
+
+  return getWatchlistItems(userId);
+}
+
+/**
+ * Persists explicit sort orders for watchlist items.
+ * Returns the updated list of watchlist rows.
+ */
+export async function reorderWatchlistItems(
+  userId: string,
+  items: WatchlistReorderItem[]
+): Promise<WatchlistItem[]> {
+  const supabase = await createClient();
+
+  for (const item of items) {
+    const { error } = await supabase
+      .from('stock_watchlist_items')
+      .update({ sort_order: item.sort_order })
+      .eq('clerk_user_id', userId)
+      .eq('symbol', item.symbol.toUpperCase());
+
+    if (error) {
+      throw new WatchlistStorageError('Failed to reorder watchlist', error);
+    }
+  }
+
+  return getWatchlistItems(userId);
 }

--- a/src/types/stocks.ts
+++ b/src/types/stocks.ts
@@ -26,6 +26,9 @@ export interface WatchlistItem {
   userId: string;
   symbol: string;
   addedAt: Date;
+  exchange?: string | null;
+  note?: string | null;
+  sort_order?: number | null;
   priceAlert?: number;
   notes?: string;
 }

--- a/src/types/watchlist.ts
+++ b/src/types/watchlist.ts
@@ -1,10 +1,9 @@
 export interface WatchlistItem {
   id: string;
-  clerk_user_id: string;
   symbol: string;
-  exchange?: string;
-  note?: string;
-  sort_order?: number;
+  exchange: string | null;
+  note: string | null;
+  sort_order: number | null;
   created_at: string;
   updated_at: string;
 }
@@ -13,6 +12,7 @@ export interface WatchlistOperationResult {
   success: boolean;
   data?: {
     watchlist: string[];
+    items: WatchlistItem[];
   };
   error?: {
     message: string;


### PR DESCRIPTION
## Summary
- Return full watchlist items alongside the legacy symbol list
- Support exchange, note, and sort order metadata in storage and API updates
- Group the watchlist UI by exchange and add edit/reorder controls
- Expand unit and integration coverage for metadata, grouping, and reorder flows

## Testing
- Added unit tests for watchlist storage and API route behavior
- Added component and integration tests for grouped rendering, metadata editing, and reordering