### PR TITLE
Add chart workspace persistence

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
+    "dev": "^0.1.3",
     "eslint": "8.48.0",
     "eslint-config-next": "15.1.0",
     "input-otp": "^1.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      dev:
+        specifier: ^0.1.3
+        version: 0.1.3
       eslint:
         specifier: 8.48.0
         version: 8.48.0
@@ -2988,6 +2991,9 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -3288,6 +3294,10 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  dev@0.1.3:
+    resolution: {integrity: sha512-flCHQwAkXk3+1up/wo93Ms9E5Wf9K28ZGA7Oz55nBZ8OTdPPhyvZrwsT+twtySTFHIwv0w9CUNtagZgu1MgzXQ==}
+    hasBin: true
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -3606,6 +3616,9 @@ packages:
     resolution: {integrity: sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==}
     engines: {node: '>= 12'}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -3868,6 +3881,11 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  inotify@1.4.6:
+    resolution: {integrity: sha512-WW8/uqIA04O3AePQVe/Ms3ZLR0yGamaz8YOEpaXc4WBAGOPZfzu58wWErEPSUYaPyDrJRIeCn6PEIQgC1ZyQ5w==}
+    engines: {node: '>=0.8'}
+    os: [linux]
 
   input-otp@1.4.2:
     resolution: {integrity: sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==}
@@ -4567,6 +4585,9 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nan@2.26.2:
+    resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -8757,6 +8778,10 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -9032,6 +9057,10 @@ snapshots:
   detect-newline@3.1.0: {}
 
   detect-node-es@1.1.0: {}
+
+  dev@0.1.3:
+    dependencies:
+      inotify: 1.4.6
 
   dir-glob@3.0.1:
     dependencies:
@@ -9495,6 +9524,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  file-uri-to-path@1.0.0: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -9758,6 +9789,11 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  inotify@1.4.6:
+    dependencies:
+      bindings: 1.5.0
+      nan: 2.26.2
 
   input-otp@1.4.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
@@ -10621,6 +10657,8 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
 
   ms@2.1.3: {}
+
+  nan@2.26.2: {}
 
   nanoid@3.3.11: {}
 

--- a/src/features/stock-dashboard/components/ChartPageClient.tsx
+++ b/src/features/stock-dashboard/components/ChartPageClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { QuoteProviderToggle } from './QuoteProviderToggle';
 import { useDashboardStore } from '../store';
@@ -12,74 +12,125 @@ import {
   isKLineInterval,
   type KLineInterval
 } from '@/lib/types/stock-api';
-
-function buildChartsHref(
-  searchParams: URLSearchParams,
-  symbol?: string | null,
-  interval?: KLineInterval
-) {
-  const nextSearchParams = new URLSearchParams(searchParams.toString());
-
-  if (symbol) {
-    nextSearchParams.set('symbol', symbol);
-  } else {
-    nextSearchParams.delete('symbol');
-  }
-
-  if (interval) {
-    nextSearchParams.set('interval', interval);
-  } else {
-    nextSearchParams.delete('interval');
-  }
-
-  const query = nextSearchParams.toString();
-  return query ? `/dashboard/charts?${query}` : '/dashboard/charts';
-}
+import {
+  buildChartsHref,
+  isChartRange,
+  type ChartPreferences,
+  type ChartRange
+} from '../lib/chart-workspace';
 
 export function ChartPageClient() {
   const searchParams = useSearchParams();
   const router = useRouter();
-  const { selectedTicker, setSelectedTicker, quoteProvider } =
-    useDashboardStore();
+  const {
+    selectedTicker,
+    setSelectedTicker,
+    quoteProvider,
+    hydrateFromStorage,
+    chartWorkspace,
+    setChartWorkspace,
+    setChartPreferences
+  } = useDashboardStore();
+  const [hydrated, setHydrated] = useState(false);
 
-  const symbol = searchParams.get('symbol');
+  const symbol = useMemo(() => {
+    const rawSymbol = searchParams.get('symbol')?.trim();
+    return rawSymbol ? rawSymbol.toUpperCase() : null;
+  }, [searchParams]);
   const rawInterval = searchParams.get('interval')?.toLowerCase();
-  const interval = isKLineInterval(rawInterval)
+  const queryInterval = isKLineInterval(rawInterval)
     ? rawInterval
-    : DEFAULT_KLINE_INTERVAL;
-  const intervalRef = useRef(interval);
+    : null;
+  const rawRange = searchParams.get('range')?.toLowerCase();
+  const queryRange = isChartRange(rawRange) ? rawRange : null;
 
-  intervalRef.current = interval;
+  const interval: KLineInterval =
+    queryInterval ?? chartWorkspace.interval ?? DEFAULT_KLINE_INTERVAL;
+  const range: ChartRange = queryRange ?? chartWorkspace.range;
+  const activeTicker = symbol ?? chartWorkspace.symbol ?? selectedTicker;
+  const workspaceSymbol = activeTicker ?? null;
 
   useEffect(() => {
-    if (!symbol || symbol === selectedTicker) {
+    hydrateFromStorage();
+    setHydrated(true);
+  }, [hydrateFromStorage]);
+
+  useEffect(() => {
+    if (!hydrated) {
       return;
     }
 
-    setSelectedTicker(symbol);
-  }, [selectedTicker, setSelectedTicker, symbol]);
+    if (activeTicker && activeTicker !== selectedTicker) {
+      setSelectedTicker(activeTicker);
+    }
+
+    if (
+      chartWorkspace.symbol !== workspaceSymbol ||
+      chartWorkspace.interval !== interval ||
+      chartWorkspace.range !== range
+    ) {
+      setChartWorkspace({
+        symbol: workspaceSymbol,
+        interval,
+        range
+      });
+    }
+  }, [
+    activeTicker,
+    chartWorkspace.interval,
+    chartWorkspace.range,
+    chartWorkspace.symbol,
+    hydrated,
+    interval,
+    range,
+    selectedTicker,
+    setChartWorkspace,
+    setSelectedTicker,
+    workspaceSymbol
+  ]);
 
   useEffect(() => {
-    if (symbol || !selectedTicker) {
+    if (!hydrated) {
+      return;
+    }
+
+    const nextWorkspace = {
+      ...(!symbol && activeTicker ? { symbol: activeTicker } : {}),
+      ...(!queryInterval ? { interval } : {}),
+      ...(!queryRange ? { range } : {})
+    };
+
+    if (Object.keys(nextWorkspace).length === 0) {
       return;
     }
 
     router.replace(
       buildChartsHref(
-        new URLSearchParams(),
-        selectedTicker,
-        intervalRef.current
+        new URLSearchParams(searchParams.toString()),
+        nextWorkspace
       )
     );
-  }, [router, selectedTicker, symbol]);
+  }, [
+    activeTicker,
+    hydrated,
+    interval,
+    queryInterval,
+    queryRange,
+    range,
+    router,
+    searchParams,
+    symbol
+  ]);
 
-  const activeTicker = symbol || selectedTicker;
   const handleTickerSubmit = (ticker: string) => {
     router.replace(
       buildChartsHref(
         new URLSearchParams(searchParams.toString()),
-        ticker,
-        interval
+        {
+          symbol: ticker,
+          interval,
+          range
+        }
       )
     );
   };
@@ -88,10 +139,32 @@ export function ChartPageClient() {
     router.replace(
       buildChartsHref(
         new URLSearchParams(searchParams.toString()),
-        activeTicker,
-        nextInterval
+        {
+          symbol: activeTicker,
+          interval: nextInterval,
+          range
+        }
       )
     );
+  };
+
+  const handleRangeChange = (nextRange: ChartRange) => {
+    router.replace(
+      buildChartsHref(
+        new URLSearchParams(searchParams.toString()),
+        {
+          symbol: activeTicker,
+          interval,
+          range: nextRange
+        }
+      )
+    );
+  };
+
+  const handlePreferencesChange = (
+    preferences: Partial<ChartPreferences>
+  ) => {
+    setChartPreferences(preferences);
   };
 
   return (
@@ -113,6 +186,10 @@ export function ChartPageClient() {
             provider={quoteProvider}
             interval={interval}
             onIntervalChange={handleIntervalChange}
+            range={range}
+            onRangeChange={handleRangeChange}
+            preferences={chartWorkspace.preferences}
+            onPreferencesChange={handlePreferencesChange}
             className='h-full'
           />
         ) : (

--- a/src/features/stock-dashboard/components/KLineChart.tsx
+++ b/src/features/stock-dashboard/components/KLineChart.tsx
@@ -8,16 +8,28 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
 import { CANONICAL_QUOTE_PROVIDER } from '@/lib/providers/config';
 import { validateTicker } from '@/lib/validation/ticker';
 import {
   DEFAULT_KLINE_INTERVAL,
   isKLineInterval,
+  type KLineCandle,
   type KLineInterval,
   type TimeRange
 } from '@/lib/types/stock-api';
 import { useKlineSeries } from '../hooks/useKlineSeries';
 import { createKLineChart, type KLineChartHandle } from '../lib/klinecharts';
+import {
+  DEFAULT_CHART_WORKSPACE,
+  filterCandlesByRange,
+  isChartCandleType,
+  isChartRange,
+  type ChartCandleType,
+  type ChartPreferences,
+  type ChartRange
+} from '../lib/chart-workspace';
 
 interface KLineChartProps {
   ticker: string;
@@ -25,6 +37,10 @@ interface KLineChartProps {
   provider?: string;
   interval?: KLineInterval;
   onIntervalChange?: (interval: KLineInterval) => void;
+  range?: ChartRange;
+  onRangeChange?: (range: ChartRange) => void;
+  preferences?: ChartPreferences;
+  onPreferencesChange?: (preferences: Partial<ChartPreferences>) => void;
 }
 
 const KLINE_INTERVAL_META: Record<
@@ -49,6 +65,26 @@ const KLINE_INTERVAL_OPTIONS: Array<{
   label: KLINE_INTERVAL_META[value].label
 }));
 
+const CHART_RANGE_OPTIONS: Array<{
+  label: string;
+  value: ChartRange;
+}> = [
+  { label: '1M', value: '1m' },
+  { label: '3M', value: '3m' },
+  { label: '6M', value: '6m' },
+  { label: '1Y', value: '1y' },
+  { label: 'Max', value: 'max' }
+];
+
+const CANDLE_TYPE_OPTIONS: Array<{
+  label: string;
+  value: ChartCandleType;
+}> = [
+  { label: 'Candle', value: 'candle_solid' },
+  { label: 'OHLC', value: 'ohlc' },
+  { label: 'Area', value: 'area' }
+];
+
 function getIntervalMeta(interval: KLineInterval) {
   return KLINE_INTERVAL_META[interval];
 }
@@ -67,12 +103,31 @@ function formatRangeLabel(range: TimeRange) {
   return `${start} - ${end} · ${getIntervalMeta(range.interval).badge}`;
 }
 
+function formatCandleRangeLabel(
+  candles: KLineCandle[],
+  interval: KLineInterval
+) {
+  if (candles.length === 0) {
+    return getIntervalMeta(interval).badge;
+  }
+
+  return formatRangeLabel({
+    startDate: new Date(candles[0].timestamp).toISOString(),
+    endDate: new Date(candles[candles.length - 1].timestamp).toISOString(),
+    interval
+  });
+}
+
 export function KLineChart({
   ticker,
   className,
   provider = CANONICAL_QUOTE_PROVIDER,
   interval = DEFAULT_KLINE_INTERVAL,
-  onIntervalChange
+  onIntervalChange,
+  range = DEFAULT_CHART_WORKSPACE.range,
+  onRangeChange,
+  preferences = DEFAULT_CHART_WORKSPACE.preferences,
+  onPreferencesChange
 }: KLineChartProps) {
   const validation = useMemo(() => validateTicker(ticker), [ticker]);
   const querySymbol = validation.isValid ? ticker : undefined;
@@ -87,11 +142,30 @@ export function KLineChart({
   const [chartReady, setChartReady] = useState(false);
   const [chartError, setChartError] = useState<string | null>(null);
   const [retryTrigger, setRetryTrigger] = useState(0);
+  const intervalRef = useRef(interval);
+  const preferencesRef = useRef(preferences);
+
+  intervalRef.current = interval;
+  preferencesRef.current = preferences;
+
+  const activePreferences = useMemo(
+    () => ({
+      showVolume: preferences.showVolume,
+      showGrid: preferences.showGrid,
+      candleType: preferences.candleType
+    }),
+    [preferences.candleType, preferences.showGrid, preferences.showVolume]
+  );
+
+  const filteredCandles = useMemo(
+    () => (data?.candles ? filterCandlesByRange(data.candles, range) : []),
+    [data?.candles, range]
+  );
 
   // Fix: Safe type mapping instead of assertion
   const chartData = useMemo(
     () =>
-      data?.candles.map(
+      filteredCandles.map(
         (candle) =>
           ({
             timestamp: candle.timestamp,
@@ -102,18 +176,20 @@ export function KLineChart({
             volume: candle.volume,
             turnover: 0 // KLineData requires turnover, setting default or if available
           }) as KLineData
-      ) ?? [],
-    [data]
+      ),
+    [filteredCandles]
   );
 
+  const selectedInterval = data?.range.interval ?? interval;
   const rangeLabel = useMemo(
     () =>
-      data?.range
-        ? formatRangeLabel(data.range)
-        : getIntervalMeta(interval).badge,
-    [data?.range, interval]
+      filteredCandles.length > 0
+        ? formatCandleRangeLabel(filteredCandles, selectedInterval)
+        : data?.range
+          ? formatRangeLabel(data.range)
+          : getIntervalMeta(interval).badge,
+    [data?.range, filteredCandles, interval, selectedInterval]
   );
-  const selectedInterval = data?.range.interval ?? interval;
   const intervalMeta = getIntervalMeta(selectedInterval);
 
   useEffect(() => {
@@ -133,8 +209,9 @@ export function KLineChart({
 
     createKLineChart(containerRef.current, {
       symbol: ticker,
-      interval,
-      data: []
+      interval: intervalRef.current,
+      data: [],
+      preferences: preferencesRef.current
     })
       .then((handle) => {
         if (cancelled) {
@@ -147,7 +224,6 @@ export function KLineChart({
       })
       .catch((err) => {
         if (!cancelled) {
-          console.error('Chart initialization failed:', err);
           Sentry.captureException(err);
           setChartError('Failed to initialize chart');
           setChartReady(false);
@@ -167,8 +243,8 @@ export function KLineChart({
 
   useEffect(() => {
     if (!chartRef.current || !querySymbol) return;
-    chartRef.current.update(querySymbol, chartData, interval);
-  }, [chartData, chartReady, interval, querySymbol]);
+    chartRef.current.update(querySymbol, chartData, interval, activePreferences);
+  }, [activePreferences, chartData, chartReady, interval, querySymbol]);
 
   const handleRetry = () => {
     if (chartError) {
@@ -227,29 +303,106 @@ export function KLineChart({
           </div>
           <div className='flex flex-col items-start gap-3 sm:flex-row sm:items-center lg:flex-col lg:items-end'>
             <Badge variant='outline'>{rangeLabel}</Badge>
-            <ToggleGroup
-              type='single'
-              value={interval}
-              variant='outline'
-              size='sm'
-              aria-label='K line interval'
-              className='w-full flex-wrap sm:w-auto'
-              onValueChange={(value) => {
-                if (isKLineInterval(value) && value !== interval) {
-                  onIntervalChange?.(value);
-                }
-              }}
-            >
-              {KLINE_INTERVAL_OPTIONS.map((option) => (
-                <ToggleGroupItem
-                  key={option.value}
-                  value={option.value}
-                  aria-label={`${option.label} interval`}
-                >
-                  {option.label}
-                </ToggleGroupItem>
-              ))}
-            </ToggleGroup>
+            <div className='flex flex-wrap items-center justify-start gap-2 lg:justify-end'>
+              <ToggleGroup
+                type='single'
+                value={interval}
+                variant='outline'
+                size='sm'
+                aria-label='K line interval'
+                className='w-full flex-wrap sm:w-auto'
+                onValueChange={(value) => {
+                  if (isKLineInterval(value) && value !== interval) {
+                    onIntervalChange?.(value);
+                  }
+                }}
+              >
+                {KLINE_INTERVAL_OPTIONS.map((option) => (
+                  <ToggleGroupItem
+                    key={option.value}
+                    value={option.value}
+                    aria-label={`${option.label} interval`}
+                  >
+                    {option.label}
+                  </ToggleGroupItem>
+                ))}
+              </ToggleGroup>
+              <ToggleGroup
+                type='single'
+                value={range}
+                variant='outline'
+                size='sm'
+                aria-label='Chart range'
+                className='w-full flex-wrap sm:w-auto'
+                onValueChange={(value) => {
+                  if (isChartRange(value) && value !== range) {
+                    onRangeChange?.(value);
+                  }
+                }}
+              >
+                {CHART_RANGE_OPTIONS.map((option) => (
+                  <ToggleGroupItem
+                    key={option.value}
+                    value={option.value}
+                    aria-label={`${option.label} range`}
+                  >
+                    {option.label}
+                  </ToggleGroupItem>
+                ))}
+              </ToggleGroup>
+            </div>
+            <div className='flex flex-wrap items-center justify-start gap-3 lg:justify-end'>
+              <div className='flex items-center gap-2'>
+                <Switch
+                  id='chart-volume'
+                  checked={preferences.showVolume}
+                  onCheckedChange={(showVolume) =>
+                    onPreferencesChange?.({ showVolume })
+                  }
+                />
+                <Label htmlFor='chart-volume' className='text-xs'>
+                  Volume
+                </Label>
+              </div>
+              <div className='flex items-center gap-2'>
+                <Switch
+                  id='chart-grid'
+                  checked={preferences.showGrid}
+                  onCheckedChange={(showGrid) =>
+                    onPreferencesChange?.({ showGrid })
+                  }
+                />
+                <Label htmlFor='chart-grid' className='text-xs'>
+                  Grid
+                </Label>
+              </div>
+              <ToggleGroup
+                type='single'
+                value={preferences.candleType}
+                variant='outline'
+                size='sm'
+                aria-label='Candle type'
+                className='w-full flex-wrap sm:w-auto'
+                onValueChange={(value) => {
+                  if (
+                    isChartCandleType(value) &&
+                    value !== preferences.candleType
+                  ) {
+                    onPreferencesChange?.({ candleType: value });
+                  }
+                }}
+              >
+                {CANDLE_TYPE_OPTIONS.map((option) => (
+                  <ToggleGroupItem
+                    key={option.value}
+                    value={option.value}
+                    aria-label={`${option.label} candle type`}
+                  >
+                    {option.label}
+                  </ToggleGroupItem>
+                ))}
+              </ToggleGroup>
+            </div>
           </div>
         </div>
       </CardHeader>

--- a/src/features/stock-dashboard/components/__tests__/KLineChart.test.tsx
+++ b/src/features/stock-dashboard/components/__tests__/KLineChart.test.tsx
@@ -2,38 +2,53 @@
  * @jest-environment jsdom
  */
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { KLineChart } from '../KLineChart';
 import { useKlineSeries } from '../../hooks/useKlineSeries';
-import type { KLineInterval } from '@/lib/types/stock-api';
+import { createKLineChart } from '../../lib/klinecharts';
+import type { KLineCandle, KLineInterval } from '@/lib/types/stock-api';
 
 jest.mock('../../hooks/useKlineSeries');
 jest.mock('../../lib/klinecharts', () => ({
-  createKLineChart: jest.fn().mockResolvedValue({
-    update: jest.fn(),
-    destroy: jest.fn()
-  })
+  createKLineChart: jest.fn()
 }));
 
 const mockUseKlineSeries = useKlineSeries as jest.MockedFunction<
   typeof useKlineSeries
 >;
+const mockCreateKLineChart = createKLineChart as jest.MockedFunction<
+  typeof createKLineChart
+>;
 
 describe('KLineChart', () => {
-  const buildSeries = (interval: KLineInterval = 'day') => ({
+  let mockChartHandle: {
+    update: jest.Mock;
+    destroy: jest.Mock;
+  };
+
+  const buildSeries = (
+    interval: KLineInterval = 'day',
+    candles: KLineCandle[] = []
+  ) => ({
     symbol: 'AAPL',
     range: {
       startDate: '2023-01-01T00:00:00.000Z',
       endDate: '2024-01-01T00:00:00.000Z',
       interval
     },
-    candles: [],
+    candles,
     lastUpdated: '2024-01-01T00:00:00.000Z'
   });
 
   beforeEach(() => {
     mockUseKlineSeries.mockReset();
+    mockChartHandle = {
+      update: jest.fn(),
+      destroy: jest.fn()
+    };
+    mockCreateKLineChart.mockReset();
+    mockCreateKLineChart.mockResolvedValue(mockChartHandle as any);
   });
 
   it('renders loading state and chart container', () => {
@@ -109,7 +124,9 @@ describe('KLineChart', () => {
     );
 
     expect(screen.getByText('Monthly candles')).toBeInTheDocument();
-    expect(screen.getByText(/1M/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Jan 1, 2023 - Jan 1, 2024 · 1M/)
+    ).toBeInTheDocument();
     expect(
       screen.getByRole('radio', { name: 'Month interval' })
     ).toHaveAttribute('data-state', 'on');
@@ -117,6 +134,130 @@ describe('KLineChart', () => {
     await userEvent.click(screen.getByRole('radio', { name: 'Week interval' }));
 
     expect(onIntervalChange).toHaveBeenCalledWith('week');
+  });
+
+  it('renders range and display preference controls', async () => {
+    mockUseKlineSeries.mockReturnValue({
+      data: buildSeries('day'),
+      isLoading: false,
+      isError: false,
+      error: null,
+      noData: false,
+      refetch: jest.fn()
+    } as any);
+
+    const onRangeChange = jest.fn();
+    const onPreferencesChange = jest.fn();
+
+    render(
+      <KLineChart
+        ticker='AAPL'
+        range='3m'
+        onRangeChange={onRangeChange}
+        preferences={{
+          showVolume: false,
+          showGrid: true,
+          candleType: 'area'
+        }}
+        onPreferencesChange={onPreferencesChange}
+      />
+    );
+
+    expect(screen.getByRole('radio', { name: '3M range' })).toHaveAttribute(
+      'data-state',
+      'on'
+    );
+    expect(screen.getByRole('switch', { name: 'Volume' })).not.toBeChecked();
+    expect(screen.getByRole('switch', { name: 'Grid' })).toBeChecked();
+    expect(
+      screen.getByRole('radio', { name: 'Area candle type' })
+    ).toHaveAttribute('data-state', 'on');
+
+    await userEvent.click(screen.getByRole('radio', { name: '6M range' }));
+    await userEvent.click(screen.getByRole('switch', { name: 'Grid' }));
+    await userEvent.click(
+      screen.getByRole('radio', { name: 'OHLC candle type' })
+    );
+
+    expect(onRangeChange).toHaveBeenCalledWith('6m');
+    expect(onPreferencesChange).toHaveBeenCalledWith({ showGrid: false });
+    expect(onPreferencesChange).toHaveBeenCalledWith({ candleType: 'ohlc' });
+  });
+
+  it('filters candles by range before updating the chart', async () => {
+    mockUseKlineSeries.mockReturnValue({
+      data: buildSeries('day', [
+        {
+          timestamp: Date.UTC(2024, 0, 1),
+          open: 100,
+          high: 110,
+          low: 95,
+          close: 105,
+          volume: 100
+        },
+        {
+          timestamp: Date.UTC(2024, 2, 20),
+          open: 106,
+          high: 112,
+          low: 101,
+          close: 108,
+          volume: 150
+        },
+        {
+          timestamp: Date.UTC(2024, 3, 20),
+          open: 108,
+          high: 116,
+          low: 104,
+          close: 114,
+          volume: 175
+        }
+      ]),
+      isLoading: false,
+      isError: false,
+      error: null,
+      noData: false,
+      refetch: jest.fn()
+    } as any);
+
+    render(<KLineChart ticker='AAPL' range='1m' />);
+
+    await waitFor(() => expect(mockChartHandle.update).toHaveBeenCalled());
+
+    const calls = mockChartHandle.update.mock.calls;
+    const latestCall = calls[calls.length - 1];
+
+    expect(latestCall[1]).toHaveLength(2);
+    expect(latestCall[1].map((candle: { close: number }) => candle.close)).toEqual([
+      108, 114
+    ]);
+  });
+
+  it('passes display preferences to the klinecharts adapter', async () => {
+    mockUseKlineSeries.mockReturnValue({
+      data: buildSeries('day'),
+      isLoading: false,
+      isError: false,
+      error: null,
+      noData: false,
+      refetch: jest.fn()
+    } as any);
+
+    const preferences = {
+      showVolume: false,
+      showGrid: false,
+      candleType: 'ohlc' as const
+    };
+
+    render(<KLineChart ticker='AAPL' preferences={preferences} />);
+
+    await waitFor(() => expect(mockCreateKLineChart).toHaveBeenCalled());
+
+    expect(mockCreateKLineChart).toHaveBeenCalledWith(expect.any(HTMLElement), {
+      symbol: 'AAPL',
+      interval: 'day',
+      data: [],
+      preferences
+    });
   });
 
   it('renders error state and calls retry', async () => {

--- a/src/features/stock-dashboard/components/__tests__/chart-page-client.test.tsx
+++ b/src/features/stock-dashboard/components/__tests__/chart-page-client.test.tsx
@@ -6,6 +6,12 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { ChartPageClient } from '../ChartPageClient';
 import { useDashboardStore } from '../../store';
 import { useRouter, useSearchParams } from 'next/navigation';
+import {
+  DEFAULT_CHART_WORKSPACE,
+  type ChartPreferences,
+  type ChartRange
+} from '../../lib/chart-workspace';
+import type { KLineInterval } from '@/lib/types/stock-api';
 
 jest.mock('../../store', () => ({
   useDashboardStore: jest.fn()
@@ -24,41 +30,91 @@ jest.mock('../KLineChart', () => ({
   KLineChart: ({
     ticker,
     interval,
-    onIntervalChange
+    range,
+    onIntervalChange,
+    onRangeChange,
+    onPreferencesChange
   }: {
     ticker: string;
-    interval: string;
-    onIntervalChange?: (interval: 'day' | 'week' | 'month' | 'year') => void;
+    interval: KLineInterval;
+    range: ChartRange;
+    preferences: ChartPreferences;
+    onIntervalChange?: (interval: KLineInterval) => void;
+    onRangeChange?: (range: ChartRange) => void;
+    onPreferencesChange?: (preferences: Partial<ChartPreferences>) => void;
   }) => (
     <div>
-      <div data-testid='kline-chart'>{`${ticker}:${interval}`}</div>
+      <div data-testid='kline-chart'>{`${ticker}:${interval}:${range}`}</div>
       <button type='button' onClick={() => onIntervalChange?.('year')}>
         Switch Interval
+      </button>
+      <button type='button' onClick={() => onRangeChange?.('6m')}>
+        Switch Range
+      </button>
+      <button
+        type='button'
+        onClick={() => onPreferencesChange?.({ showGrid: false })}
+      >
+        Toggle Grid
       </button>
     </div>
   )
 }));
+
+function createSearchParams(params: Record<string, string | null>) {
+  return {
+    get: (key: string) => params[key] ?? null,
+    toString: () => {
+      const searchParams = new URLSearchParams();
+      Object.entries(params).forEach(([key, value]) => {
+        if (value !== null) {
+          searchParams.set(key, value);
+        }
+      });
+      return searchParams.toString();
+    }
+  };
+}
+
+function createStore(overrides: Record<string, unknown> = {}) {
+  return {
+    selectedTicker: null,
+    setSelectedTicker: jest.fn(),
+    quoteProvider: 'default',
+    hydrateFromStorage: jest.fn(),
+    chartWorkspace: DEFAULT_CHART_WORKSPACE,
+    setChartWorkspace: jest.fn(),
+    setChartPreferences: jest.fn(),
+    ...overrides
+  };
+}
 
 describe('ChartPageClient', () => {
   beforeEach(() => {
     jest.resetAllMocks();
   });
 
-  test('replaces the symbol query param when searching from the charts page and preserves the interval', () => {
+  test('replaces the symbol query param when searching from the charts page and preserves the interval and range', () => {
     const replace = jest.fn();
-    const setSelectedTicker = jest.fn();
+    const store = createStore({
+      selectedTicker: 'GOOGL',
+      chartWorkspace: {
+        ...DEFAULT_CHART_WORKSPACE,
+        symbol: 'GOOGL',
+        interval: 'week',
+        range: '3m'
+      }
+    });
 
     (useRouter as jest.Mock).mockReturnValue({ replace });
-    (useSearchParams as jest.Mock).mockReturnValue({
-      get: (key: string) =>
-        key === 'symbol' ? 'GOOGL' : key === 'interval' ? 'week' : null,
-      toString: () => 'symbol=GOOGL&interval=week'
-    });
-    (useDashboardStore as unknown as jest.Mock).mockReturnValue({
-      selectedTicker: 'GOOGL',
-      setSelectedTicker,
-      quoteProvider: 'default'
-    });
+    (useSearchParams as jest.Mock).mockReturnValue(
+      createSearchParams({
+        symbol: 'GOOGL',
+        interval: 'week',
+        range: '3m'
+      })
+    );
+    (useDashboardStore as unknown as jest.Mock).mockReturnValue(store);
 
     render(<ChartPageClient />);
 
@@ -67,88 +123,162 @@ describe('ChartPageClient', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: 'Search' }));
 
-    expect(replace).toHaveBeenCalledWith(
-      '/dashboard/charts?symbol=AAPL&interval=week'
+    expect(replace).toHaveBeenLastCalledWith(
+      '/dashboard/charts?symbol=AAPL&interval=week&range=3m'
     );
-    expect(setSelectedTicker).not.toHaveBeenCalled();
+    expect(store.setSelectedTicker).not.toHaveBeenCalled();
   });
 
-  test('passes the selected interval from the URL into the chart', () => {
+  test('passes the selected interval and range from the URL into the chart', () => {
     (useRouter as jest.Mock).mockReturnValue({ replace: jest.fn() });
-    (useSearchParams as jest.Mock).mockReturnValue({
-      get: (key: string) =>
-        key === 'symbol' ? 'GOOGL' : key === 'interval' ? 'month' : null,
-      toString: () => 'symbol=GOOGL&interval=month'
-    });
-    (useDashboardStore as unknown as jest.Mock).mockReturnValue({
+    (useSearchParams as jest.Mock).mockReturnValue(
+      createSearchParams({
+        symbol: 'GOOGL',
+        interval: 'month',
+        range: '6m'
+      })
+    );
+    (useDashboardStore as unknown as jest.Mock).mockReturnValue(createStore({
       selectedTicker: 'GOOGL',
-      setSelectedTicker: jest.fn(),
-      quoteProvider: 'default'
-    });
+      chartWorkspace: {
+        ...DEFAULT_CHART_WORKSPACE,
+        symbol: 'AAPL',
+        interval: 'day',
+        range: '1m'
+      }
+    }));
 
     render(<ChartPageClient />);
 
-    expect(screen.getByTestId('kline-chart')).toHaveTextContent('GOOGL:month');
+    expect(screen.getByTestId('kline-chart')).toHaveTextContent(
+      'GOOGL:month:6m'
+    );
   });
 
-  test('defaults the chart interval to day when the URL omits it', () => {
+  test('defaults the chart interval and range when the URL omits them', () => {
     (useRouter as jest.Mock).mockReturnValue({ replace: jest.fn() });
-    (useSearchParams as jest.Mock).mockReturnValue({
-      get: (key: string) => (key === 'symbol' ? 'AAPL' : null),
-      toString: () => 'symbol=AAPL'
-    });
-    (useDashboardStore as unknown as jest.Mock).mockReturnValue({
+    (useSearchParams as jest.Mock).mockReturnValue(
+      createSearchParams({ symbol: 'AAPL' })
+    );
+    (useDashboardStore as unknown as jest.Mock).mockReturnValue(createStore({
       selectedTicker: 'AAPL',
-      setSelectedTicker: jest.fn(),
-      quoteProvider: 'default'
-    });
+      chartWorkspace: {
+        ...DEFAULT_CHART_WORKSPACE,
+        symbol: 'AAPL'
+      }
+    }));
 
     render(<ChartPageClient />);
 
-    expect(screen.getByTestId('kline-chart')).toHaveTextContent('AAPL:day');
+    expect(screen.getByTestId('kline-chart')).toHaveTextContent('AAPL:day:1y');
   });
 
-  test('hydrates the missing symbol in the URL from the store without dropping the interval', () => {
+  test('hydrates missing URL workspace fields from the store', () => {
     const replace = jest.fn();
 
     (useRouter as jest.Mock).mockReturnValue({ replace });
-    (useSearchParams as jest.Mock).mockReturnValue({
-      get: (key: string) => (key === 'interval' ? 'month' : null),
-      toString: () => 'interval=month'
-    });
-    (useDashboardStore as unknown as jest.Mock).mockReturnValue({
-      selectedTicker: 'NVDA',
-      setSelectedTicker: jest.fn(),
-      quoteProvider: 'default'
-    });
+    (useSearchParams as jest.Mock).mockReturnValue(createSearchParams({}));
+    (useDashboardStore as unknown as jest.Mock).mockReturnValue(createStore({
+      chartWorkspace: {
+        ...DEFAULT_CHART_WORKSPACE,
+        symbol: 'NVDA',
+        interval: 'month',
+        range: '3m'
+      }
+    }));
 
     render(<ChartPageClient />);
 
     expect(replace).toHaveBeenCalledWith(
-      '/dashboard/charts?symbol=NVDA&interval=month'
+      '/dashboard/charts?symbol=NVDA&interval=month&range=3m'
     );
   });
 
-  test('preserves the symbol when the chart interval changes', () => {
+  test('preserves the symbol and range when the chart interval changes', () => {
     const replace = jest.fn();
 
     (useRouter as jest.Mock).mockReturnValue({ replace });
-    (useSearchParams as jest.Mock).mockReturnValue({
-      get: (key: string) =>
-        key === 'symbol' ? 'MSFT' : key === 'interval' ? 'week' : null,
-      toString: () => 'symbol=MSFT&interval=week'
-    });
-    (useDashboardStore as unknown as jest.Mock).mockReturnValue({
+    (useSearchParams as jest.Mock).mockReturnValue(
+      createSearchParams({
+        symbol: 'MSFT',
+        interval: 'week',
+        range: '3m'
+      })
+    );
+    (useDashboardStore as unknown as jest.Mock).mockReturnValue(createStore({
       selectedTicker: 'MSFT',
-      setSelectedTicker: jest.fn(),
-      quoteProvider: 'default'
-    });
+      chartWorkspace: {
+        ...DEFAULT_CHART_WORKSPACE,
+        symbol: 'MSFT',
+        interval: 'week',
+        range: '3m'
+      }
+    }));
 
     render(<ChartPageClient />);
     fireEvent.click(screen.getByRole('button', { name: 'Switch Interval' }));
 
-    expect(replace).toHaveBeenCalledWith(
-      '/dashboard/charts?symbol=MSFT&interval=year'
+    expect(replace).toHaveBeenLastCalledWith(
+      '/dashboard/charts?symbol=MSFT&interval=year&range=3m'
     );
+  });
+
+  test('preserves the symbol and interval when the chart range changes', () => {
+    const replace = jest.fn();
+
+    (useRouter as jest.Mock).mockReturnValue({ replace });
+    (useSearchParams as jest.Mock).mockReturnValue(
+      createSearchParams({
+        symbol: 'MSFT',
+        interval: 'week',
+        range: '3m'
+      })
+    );
+    (useDashboardStore as unknown as jest.Mock).mockReturnValue(createStore({
+      selectedTicker: 'MSFT',
+      chartWorkspace: {
+        ...DEFAULT_CHART_WORKSPACE,
+        symbol: 'MSFT',
+        interval: 'week',
+        range: '3m'
+      }
+    }));
+
+    render(<ChartPageClient />);
+    fireEvent.click(screen.getByRole('button', { name: 'Switch Range' }));
+
+    expect(replace).toHaveBeenLastCalledWith(
+      '/dashboard/charts?symbol=MSFT&interval=week&range=6m'
+    );
+  });
+
+  test('persists preference changes without adding preferences to the URL', () => {
+    const replace = jest.fn();
+    const setChartPreferences = jest.fn();
+
+    (useRouter as jest.Mock).mockReturnValue({ replace });
+    (useSearchParams as jest.Mock).mockReturnValue(
+      createSearchParams({
+        symbol: 'MSFT',
+        interval: 'week',
+        range: '3m'
+      })
+    );
+    (useDashboardStore as unknown as jest.Mock).mockReturnValue(createStore({
+      selectedTicker: 'MSFT',
+      setChartPreferences,
+      chartWorkspace: {
+        ...DEFAULT_CHART_WORKSPACE,
+        symbol: 'MSFT',
+        interval: 'week',
+        range: '3m'
+      }
+    }));
+
+    render(<ChartPageClient />);
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle Grid' }));
+
+    expect(setChartPreferences).toHaveBeenCalledWith({ showGrid: false });
+    expect(replace).not.toHaveBeenCalled();
   });
 });

--- a/src/features/stock-dashboard/lib/chart-workspace.ts
+++ b/src/features/stock-dashboard/lib/chart-workspace.ts
@@ -1,0 +1,162 @@
+import {
+  DEFAULT_KLINE_INTERVAL,
+  isKLineInterval,
+  type KLineCandle,
+  type KLineInterval
+} from '@/lib/types/stock-api';
+
+export const CHART_WORKSPACE_STORAGE_KEY = 'dashboard:chartWorkspace:v1';
+
+export const CHART_RANGES = ['1m', '3m', '6m', '1y', 'max'] as const;
+export type ChartRange = (typeof CHART_RANGES)[number];
+
+export const CHART_CANDLE_TYPES = [
+  'candle_solid',
+  'ohlc',
+  'area'
+] as const;
+export type ChartCandleType = (typeof CHART_CANDLE_TYPES)[number];
+
+export interface ChartPreferences {
+  showVolume: boolean;
+  showGrid: boolean;
+  candleType: ChartCandleType;
+}
+
+export interface ChartWorkspace {
+  symbol: string | null;
+  interval: KLineInterval;
+  range: ChartRange;
+  preferences: ChartPreferences;
+}
+
+export type ChartWorkspacePatch = Partial<
+  Pick<ChartWorkspace, 'symbol' | 'interval' | 'range'>
+>;
+
+export const DEFAULT_CHART_WORKSPACE: ChartWorkspace = {
+  symbol: null,
+  interval: DEFAULT_KLINE_INTERVAL,
+  range: '1y',
+  preferences: {
+    showVolume: true,
+    showGrid: true,
+    candleType: 'candle_solid'
+  }
+};
+
+export function isChartRange(
+  value: string | null | undefined
+): value is ChartRange {
+  return CHART_RANGES.includes(value as ChartRange);
+}
+
+export function isChartCandleType(
+  value: string | null | undefined
+): value is ChartCandleType {
+  return CHART_CANDLE_TYPES.includes(value as ChartCandleType);
+}
+
+export function parseChartWorkspace(raw: string | null): ChartWorkspace {
+  if (!raw) {
+    return DEFAULT_CHART_WORKSPACE;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<ChartWorkspace>;
+
+    if (!parsed || typeof parsed !== 'object') {
+      return DEFAULT_CHART_WORKSPACE;
+    }
+
+    const preferences = parsed.preferences;
+
+    return {
+      symbol:
+        typeof parsed.symbol === 'string' && parsed.symbol.trim()
+          ? parsed.symbol.trim().toUpperCase()
+          : DEFAULT_CHART_WORKSPACE.symbol,
+      interval: isKLineInterval(parsed.interval)
+        ? parsed.interval
+        : DEFAULT_CHART_WORKSPACE.interval,
+      range: isChartRange(parsed.range)
+        ? parsed.range
+        : DEFAULT_CHART_WORKSPACE.range,
+      preferences: {
+        showVolume:
+          typeof preferences?.showVolume === 'boolean'
+            ? preferences.showVolume
+            : DEFAULT_CHART_WORKSPACE.preferences.showVolume,
+        showGrid:
+          typeof preferences?.showGrid === 'boolean'
+            ? preferences.showGrid
+            : DEFAULT_CHART_WORKSPACE.preferences.showGrid,
+        candleType: isChartCandleType(preferences?.candleType)
+          ? preferences.candleType
+          : DEFAULT_CHART_WORKSPACE.preferences.candleType
+      }
+    };
+  } catch {
+    return DEFAULT_CHART_WORKSPACE;
+  }
+}
+
+export function filterCandlesByRange(
+  candles: KLineCandle[],
+  range: ChartRange
+): KLineCandle[] {
+  if (range === 'max' || candles.length === 0) {
+    return candles;
+  }
+
+  const endTimestamp = candles.reduce(
+    (latest, candle) => Math.max(latest, candle.timestamp),
+    candles[0].timestamp
+  );
+  const startDate = new Date(endTimestamp);
+
+  if (range === '1y') {
+    startDate.setFullYear(startDate.getFullYear() - 1);
+  } else {
+    const months = range === '1m' ? 1 : range === '3m' ? 3 : 6;
+    startDate.setMonth(startDate.getMonth() - months);
+  }
+
+  const filtered = candles.filter((candle) => candle.timestamp >= startDate.getTime());
+
+  return filtered.length > 0 ? filtered : [candles[candles.length - 1]];
+}
+
+export function buildChartsHref(
+  searchParams: URLSearchParams,
+  workspacePatch: ChartWorkspacePatch
+) {
+  const nextSearchParams = new URLSearchParams(searchParams.toString());
+
+  if ('symbol' in workspacePatch) {
+    if (workspacePatch.symbol) {
+      nextSearchParams.set('symbol', workspacePatch.symbol);
+    } else {
+      nextSearchParams.delete('symbol');
+    }
+  }
+
+  if ('interval' in workspacePatch) {
+    if (workspacePatch.interval) {
+      nextSearchParams.set('interval', workspacePatch.interval);
+    } else {
+      nextSearchParams.delete('interval');
+    }
+  }
+
+  if ('range' in workspacePatch) {
+    if (workspacePatch.range) {
+      nextSearchParams.set('range', workspacePatch.range);
+    } else {
+      nextSearchParams.delete('range');
+    }
+  }
+
+  const query = nextSearchParams.toString();
+  return query ? `/dashboard/charts?${query}` : '/dashboard/charts';
+}

--- a/src/features/stock-dashboard/lib/klinecharts.ts
+++ b/src/features/stock-dashboard/lib/klinecharts.ts
@@ -1,8 +1,17 @@
 import type { Chart, KLineData } from 'klinecharts';
 import type { KLineInterval } from '@/lib/types/stock-api';
+import {
+  DEFAULT_CHART_WORKSPACE,
+  type ChartPreferences
+} from './chart-workspace';
 
 export interface KLineChartHandle {
-  update: (symbol: string, data: KLineData[], interval: KLineInterval) => void;
+  update: (
+    symbol: string,
+    data: KLineData[],
+    interval: KLineInterval,
+    preferences?: ChartPreferences
+  ) => void;
   destroy: () => void;
 }
 
@@ -10,6 +19,7 @@ export interface CreateKLineChartOptions {
   symbol: string;
   interval: KLineInterval;
   data?: KLineData[];
+  preferences?: ChartPreferences;
 }
 
 let klineModule: typeof import('klinecharts') | null = null;
@@ -41,6 +51,48 @@ function applyData(
   chart.resetData();
 }
 
+function applyPreferences(chart: Chart, preferences: ChartPreferences) {
+  chart.setStyles({
+    grid: {
+      show: preferences.showGrid,
+      horizontal: {
+        show: preferences.showGrid
+      },
+      vertical: {
+        show: preferences.showGrid
+      }
+    },
+    candle: {
+      type: preferences.candleType
+    }
+  });
+
+  const volumeIndicators = chart.getIndicators({ name: 'VOL' });
+
+  if (preferences.showVolume && volumeIndicators.length === 0) {
+    chart.createIndicator('VOL', false, {
+      id: 'volume-pane',
+      height: 120,
+      minHeight: 80
+    });
+  }
+
+  if (!preferences.showVolume && volumeIndicators.length > 0) {
+    chart.removeIndicator({ name: 'VOL' });
+  }
+}
+
+function updateChart(
+  chart: Chart,
+  symbol: string,
+  data: KLineData[],
+  interval: KLineInterval,
+  preferences: ChartPreferences
+) {
+  applyPreferences(chart, preferences);
+  applyData(chart, symbol, data, interval);
+}
+
 export async function createKLineChart(
   container: HTMLElement,
   options: CreateKLineChartOptions
@@ -52,7 +104,13 @@ export async function createKLineChart(
     throw new Error('Failed to initialize kline chart');
   }
 
-  applyData(chart, options.symbol, options.data ?? [], options.interval);
+  updateChart(
+    chart,
+    options.symbol,
+    options.data ?? [],
+    options.interval,
+    options.preferences ?? DEFAULT_CHART_WORKSPACE.preferences
+  );
 
   const resizeObserver = new ResizeObserver(() => {
     chart.resize();
@@ -61,8 +119,19 @@ export async function createKLineChart(
   resizeObserver.observe(container);
 
   return {
-    update: (symbol, data, interval) =>
-      applyData(chart, symbol, data, interval),
+    update: (
+      symbol,
+      data,
+      interval,
+      preferences = options.preferences ?? DEFAULT_CHART_WORKSPACE.preferences
+    ) =>
+      updateChart(
+        chart,
+        symbol,
+        data,
+        interval,
+        preferences
+      ),
     destroy: () => {
       resizeObserver.disconnect();
       dispose(chart);

--- a/src/features/stock-dashboard/store.test.ts
+++ b/src/features/stock-dashboard/store.test.ts
@@ -4,6 +4,10 @@
 import { act } from '@testing-library/react';
 import { useDashboardStore } from './store';
 import { CANONICAL_QUOTE_PROVIDER } from '@/lib/providers/config';
+import {
+  CHART_WORKSPACE_STORAGE_KEY,
+  DEFAULT_CHART_WORKSPACE
+} from './lib/chart-workspace';
 
 const removedProvider = ['alpha', 'vantage'].join('');
 
@@ -16,7 +20,8 @@ describe('dashboard provider state', () => {
       loading: false,
       wsConnected: false,
       lastTickers: [],
-      quoteProvider: CANONICAL_QUOTE_PROVIDER
+      quoteProvider: CANONICAL_QUOTE_PROVIDER,
+      chartWorkspace: DEFAULT_CHART_WORKSPACE
     });
   });
 
@@ -61,5 +66,101 @@ describe('dashboard provider state', () => {
     expect(localStorage.getItem('dashboard:quoteProvider')).toBe(
       CANONICAL_QUOTE_PROVIDER
     );
+  });
+
+  it('hydrates a valid persisted chart workspace', () => {
+    localStorage.setItem(
+      CHART_WORKSPACE_STORAGE_KEY,
+      JSON.stringify({
+        symbol: 'msft',
+        interval: 'week',
+        range: '3m',
+        preferences: {
+          showVolume: false,
+          showGrid: true,
+          candleType: 'area'
+        }
+      })
+    );
+
+    act(() => {
+      useDashboardStore.getState().hydrateFromStorage();
+    });
+
+    expect(useDashboardStore.getState().chartWorkspace).toEqual({
+      symbol: 'MSFT',
+      interval: 'week',
+      range: '3m',
+      preferences: {
+        showVolume: false,
+        showGrid: true,
+        candleType: 'area'
+      }
+    });
+  });
+
+  it('falls back to chart workspace defaults for malformed storage', () => {
+    localStorage.setItem(CHART_WORKSPACE_STORAGE_KEY, '{bad json');
+
+    act(() => {
+      useDashboardStore.getState().hydrateFromStorage();
+    });
+
+    expect(useDashboardStore.getState().chartWorkspace).toEqual(
+      DEFAULT_CHART_WORKSPACE
+    );
+  });
+
+  it('ignores invalid chart workspace enum values during hydration', () => {
+    localStorage.setItem(
+      CHART_WORKSPACE_STORAGE_KEY,
+      JSON.stringify({
+        symbol: '',
+        interval: 'quarter',
+        range: '10y',
+        preferences: {
+          showVolume: 'yes',
+          showGrid: false,
+          candleType: 'renko'
+        }
+      })
+    );
+
+    act(() => {
+      useDashboardStore.getState().hydrateFromStorage();
+    });
+
+    expect(useDashboardStore.getState().chartWorkspace).toEqual({
+      ...DEFAULT_CHART_WORKSPACE,
+      preferences: {
+        ...DEFAULT_CHART_WORKSPACE.preferences,
+        showGrid: false
+      }
+    });
+  });
+
+  it('persists chart workspace updates with minimal fields', () => {
+    act(() => {
+      useDashboardStore.getState().setChartWorkspace({
+        symbol: 'NVDA',
+        interval: 'month',
+        range: '6m'
+      });
+      useDashboardStore.getState().setChartPreferences({
+        showVolume: false,
+        candleType: 'ohlc'
+      });
+    });
+
+    expect(JSON.parse(localStorage.getItem(CHART_WORKSPACE_STORAGE_KEY)!)).toEqual({
+      symbol: 'NVDA',
+      interval: 'month',
+      range: '6m',
+      preferences: {
+        showVolume: false,
+        showGrid: true,
+        candleType: 'ohlc'
+      }
+    });
   });
 });

--- a/src/features/stock-dashboard/store.ts
+++ b/src/features/stock-dashboard/store.ts
@@ -5,6 +5,13 @@ import {
   type CanonicalQuoteProvider,
   migrateStoredQuoteProvider
 } from '@/lib/providers/config';
+import {
+  CHART_WORKSPACE_STORAGE_KEY,
+  DEFAULT_CHART_WORKSPACE,
+  parseChartWorkspace,
+  type ChartPreferences,
+  type ChartWorkspace
+} from './lib/chart-workspace';
 
 const LAST_TICKERS_STORAGE_KEY = 'dashboard:lastTickers';
 const QUOTE_PROVIDER_STORAGE_KEY = 'dashboard:quoteProvider';
@@ -16,6 +23,7 @@ interface DashboardState {
   wsConnected: boolean;
   lastTickers: string[];
   quoteProvider: CanonicalQuoteProvider;
+  chartWorkspace: ChartWorkspace;
 }
 
 interface DashboardActions {
@@ -24,7 +32,22 @@ interface DashboardActions {
   setWsConnected: (connected: boolean) => void;
   addToLastTickers: (ticker: string) => void;
   setQuoteProvider: (provider: string) => void;
+  setChartWorkspace: (workspace: Partial<ChartWorkspace>) => void;
+  setChartPreferences: (preferences: Partial<ChartPreferences>) => void;
   hydrateFromStorage: () => void;
+}
+
+function persistChartWorkspace(chartWorkspace: ChartWorkspace) {
+  if (typeof window === 'undefined') return;
+
+  try {
+    localStorage.setItem(
+      CHART_WORKSPACE_STORAGE_KEY,
+      JSON.stringify(chartWorkspace)
+    );
+  } catch {
+    // Ignore unavailable storage in private browsing or quota failures.
+  }
 }
 
 export const useDashboardStore = create<DashboardState & DashboardActions>()(
@@ -34,6 +57,7 @@ export const useDashboardStore = create<DashboardState & DashboardActions>()(
     wsConnected: false,
     lastTickers: [],
     quoteProvider: CANONICAL_QUOTE_PROVIDER,
+    chartWorkspace: DEFAULT_CHART_WORKSPACE,
 
     setSelectedTicker: (ticker: string) => {
       const previousTicker = get().selectedTicker;
@@ -81,6 +105,35 @@ export const useDashboardStore = create<DashboardState & DashboardActions>()(
       }
     },
 
+    setChartWorkspace: (workspace: Partial<ChartWorkspace>) => {
+      const current = get().chartWorkspace;
+      const nextWorkspace = {
+        ...current,
+        ...workspace,
+        preferences: {
+          ...current.preferences,
+          ...(workspace.preferences ?? {})
+        }
+      };
+
+      set({ chartWorkspace: nextWorkspace });
+      persistChartWorkspace(nextWorkspace);
+    },
+
+    setChartPreferences: (preferences: Partial<ChartPreferences>) => {
+      const current = get().chartWorkspace;
+      const nextWorkspace = {
+        ...current,
+        preferences: {
+          ...current.preferences,
+          ...preferences
+        }
+      };
+
+      set({ chartWorkspace: nextWorkspace });
+      persistChartWorkspace(nextWorkspace);
+    },
+
     hydrateFromStorage: () => {
       if (typeof window === 'undefined') return;
 
@@ -89,6 +142,7 @@ export const useDashboardStore = create<DashboardState & DashboardActions>()(
       );
       const lastTickers = localStorage.getItem(LAST_TICKERS_STORAGE_KEY);
       const quoteProvider = localStorage.getItem(QUOTE_PROVIDER_STORAGE_KEY);
+      const chartWorkspace = localStorage.getItem(CHART_WORKSPACE_STORAGE_KEY);
 
       if (selectedTicker) {
         set({ selectedTicker });
@@ -110,6 +164,8 @@ export const useDashboardStore = create<DashboardState & DashboardActions>()(
           localStorage.setItem(QUOTE_PROVIDER_STORAGE_KEY, migratedProvider);
         }
       }
+
+      set({ chartWorkspace: parseChartWorkspace(chartWorkspace) });
     }
   })
 );


### PR DESCRIPTION
## Summary
- Persist chart workspace state in browser storage with versioned helpers.
- Keep charts URL params authoritative when present, and hydrate missing state from storage.
- Add chart range and display preference controls, plus klinecharts support for grid, candle type, and volume visibility.
- Cover the new workspace flow with store, page, and chart unit tests.

## Testing
- Added and updated unit tests for workspace hydration, URL reconciliation, chart controls, and chart adapter behavior.
- Not run (not requested)