### PR TITLE
Add Longbridge market data reliability

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
+    "dev": "^0.1.3",
     "eslint": "8.48.0",
     "eslint-config-next": "15.1.0",
     "input-otp": "^1.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      dev:
+        specifier: ^0.1.3
+        version: 0.1.3
       eslint:
         specifier: 8.48.0
         version: 8.48.0
@@ -2988,6 +2991,9 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -3288,6 +3294,10 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  dev@0.1.3:
+    resolution: {integrity: sha512-flCHQwAkXk3+1up/wo93Ms9E5Wf9K28ZGA7Oz55nBZ8OTdPPhyvZrwsT+twtySTFHIwv0w9CUNtagZgu1MgzXQ==}
+    hasBin: true
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -3606,6 +3616,9 @@ packages:
     resolution: {integrity: sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==}
     engines: {node: '>= 12'}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -3868,6 +3881,11 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  inotify@1.4.6:
+    resolution: {integrity: sha512-WW8/uqIA04O3AePQVe/Ms3ZLR0yGamaz8YOEpaXc4WBAGOPZfzu58wWErEPSUYaPyDrJRIeCn6PEIQgC1ZyQ5w==}
+    engines: {node: '>=0.8'}
+    os: [linux]
 
   input-otp@1.4.2:
     resolution: {integrity: sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==}
@@ -4567,6 +4585,9 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nan@2.26.2:
+    resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -8757,6 +8778,10 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -9032,6 +9057,10 @@ snapshots:
   detect-newline@3.1.0: {}
 
   detect-node-es@1.1.0: {}
+
+  dev@0.1.3:
+    dependencies:
+      inotify: 1.4.6
 
   dir-glob@3.0.1:
     dependencies:
@@ -9495,6 +9524,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  file-uri-to-path@1.0.0: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -9758,6 +9789,11 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  inotify@1.4.6:
+    dependencies:
+      bindings: 1.5.0
+      nan: 2.26.2
 
   input-otp@1.4.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
@@ -10621,6 +10657,8 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
 
   ms@2.1.3: {}
+
+  nan@2.26.2: {}
 
   nanoid@3.3.11: {}
 

--- a/src/app/api/stocks/kline/[symbol]/__tests__/route.test.ts
+++ b/src/app/api/stocks/kline/[symbol]/__tests__/route.test.ts
@@ -259,7 +259,10 @@ describe('/api/stocks/kline/[symbol] API Route', () => {
   it('maps API_LIMIT_EXCEEDED to 429', async () => {
     mockStockServiceInstance.getKLineSeries.mockRejectedValue({
       code: 'API_LIMIT_EXCEEDED',
-      message: 'Rate limit'
+      message: 'Rate limit',
+      details: {
+        retryAfter: 7
+      }
     });
 
     const response = await GET(
@@ -270,6 +273,7 @@ describe('/api/stocks/kline/[symbol] API Route', () => {
     );
 
     expect(response.status).toBe(429);
+    expect(response.headers.get('Retry-After')).toBe('7');
   });
 
   it('maps NETWORK_ERROR to 502', async () => {

--- a/src/app/api/stocks/kline/[symbol]/route.ts
+++ b/src/app/api/stocks/kline/[symbol]/route.ts
@@ -1,15 +1,16 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import * as Sentry from '@sentry/nextjs';
 import { CANONICAL_QUOTE_PROVIDER } from '@/lib/providers/config';
 import { getStockService } from '@/lib/services/stock-service';
-import { validateTicker, normalizeTicker } from '@/lib/validation/ticker';
 import {
-  APIResponse,
-  APIError,
-  DEFAULT_KLINE_INTERVAL,
-  isKLineInterval,
-  KLineSeries
-} from '@/lib/types/stock-api';
+  createAPIError,
+  createErrorResponse,
+  createSuccessResponse,
+  getStatusCodeForError,
+  isAPIError
+} from '@/lib/services/api-errors';
+import { validateTicker, normalizeTicker } from '@/lib/validation/ticker';
+import { DEFAULT_KLINE_INTERVAL, isKLineInterval } from '@/lib/types/stock-api';
 import { logger } from '@/lib/logger';
 
 const CACHE_HEADER = 'public, s-maxage=86400, stale-while-revalidate=604800';
@@ -32,10 +33,10 @@ export async function GET(
 
         const validation = validateTicker(symbol);
         if (!validation.isValid) {
-          const error: APIError = {
-            code: 'INVALID_SYMBOL',
-            message: validation.error || 'Invalid ticker symbol'
-          };
+          const error = createAPIError(
+            'INVALID_SYMBOL',
+            validation.error || 'Invalid ticker symbol'
+          );
 
           logger.warn(`API Error: ${error.message}`, {
             symbol: rawSymbol,
@@ -43,14 +44,7 @@ export async function GET(
             path: requestPath
           });
 
-          const response: APIResponse<null> = {
-            success: false,
-            data: null,
-            error,
-            timestamp: new Date().toISOString()
-          };
-
-          return NextResponse.json(response, { status: 400 });
+          return createErrorResponse(error, 400);
         }
 
         const url = new URL(request.url);
@@ -60,10 +54,10 @@ export async function GET(
         const normalizedInterval = rawInterval?.toLowerCase();
 
         if (rawInterval && !isKLineInterval(normalizedInterval)) {
-          const error: APIError = {
-            code: 'INVALID_INTERVAL',
-            message: `Unsupported kline interval: ${rawInterval}`
-          };
+          const error = createAPIError(
+            'INVALID_INTERVAL',
+            `Unsupported kline interval: ${rawInterval}`
+          );
 
           logger.warn(`API Error: ${error.message}`, {
             symbol,
@@ -72,14 +66,7 @@ export async function GET(
             interval: rawInterval
           });
 
-          const response: APIResponse<null> = {
-            success: false,
-            data: null,
-            error,
-            timestamp: new Date().toISOString()
-          };
-
-          return NextResponse.json(response, { status: 400 });
+          return createErrorResponse(error, 400);
         }
 
         const interval = isKLineInterval(normalizedInterval)
@@ -97,18 +84,8 @@ export async function GET(
 
         span?.setAttribute('kline.candles', series.candles.length);
 
-        const response: APIResponse<KLineSeries> = {
-          success: true,
-          data: series,
-          error: null,
-          timestamp: new Date().toISOString()
-        };
-
-        return NextResponse.json(response, {
-          status: 200,
-          headers: {
-            'Cache-Control': CACHE_HEADER
-          }
+        return createSuccessResponse(series, {
+          'Cache-Control': CACHE_HEADER
         });
       } catch (error) {
         Sentry.captureException(error);
@@ -127,22 +104,7 @@ export async function GET(
             logger.warn(`API Warning: ${error.message}`, logContext);
           }
 
-          const response: APIResponse<null> = {
-            success: false,
-            data: null,
-            error,
-            timestamp: new Date().toISOString()
-          };
-
-          const options: { status: number; headers?: Record<string, string> } =
-            { status: statusCode };
-          if (statusCode === 429) {
-            options.headers = {
-              'Retry-After': '60'
-            };
-          }
-
-          return NextResponse.json(response, options);
+          return createErrorResponse(error);
         }
 
         logger.error('API Unexpected Error', {
@@ -150,47 +112,16 @@ export async function GET(
           error
         });
 
-        const response: APIResponse<null> = {
-          success: false,
-          data: null,
-          error: {
+        return createErrorResponse(
+          {
             code: 'UNKNOWN_ERROR',
             message: 'An unexpected error occurred'
           },
-          timestamp: new Date().toISOString()
-        };
-
-        return NextResponse.json(response, { status: 500 });
+          500
+        );
       }
     }
   );
-}
-
-function isAPIError(error: unknown): error is APIError {
-  return (
-    error !== null &&
-    typeof error === 'object' &&
-    'code' in error &&
-    'message' in error
-  );
-}
-
-function getStatusCodeForError(code: string): number {
-  switch (code) {
-    case 'INVALID_SYMBOL':
-    case 'INVALID_INTERVAL':
-    case 'INVALID_PROVIDER':
-      return 400;
-    case 'API_LIMIT_EXCEEDED':
-      return 429;
-    case 'INVALID_API_KEY':
-      return 401;
-    case 'NETWORK_ERROR':
-      return 502;
-    case 'UNKNOWN_ERROR':
-    default:
-      return 500;
-  }
 }
 
 function getRequestPath(request: NextRequest): string {

--- a/src/app/api/stocks/providers/health/__tests__/route.test.ts
+++ b/src/app/api/stocks/providers/health/__tests__/route.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @jest-environment jsdom
+ */
+import { GET } from '../route';
+import { StockProviderFactory } from '@/lib/providers/factory';
+import { APIResponse } from '@/lib/types/stock-api';
+import { ProviderHealthCheck } from '@/lib/providers/types';
+import { createMockRequest } from '../../../__tests__/request-fixtures';
+
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: jest.fn().mockImplementation((data, init) => {
+      const headers = new Map<string, string>();
+
+      if (init?.headers) {
+        Object.entries(init.headers).forEach(([key, value]) => {
+          headers.set(key, value as string);
+        });
+      }
+
+      return {
+        json: () => Promise.resolve(data),
+        status: init?.status || 200,
+        headers: {
+          get: (key: string) => headers.get(key)
+        }
+      };
+    })
+  },
+  NextRequest: class NextRequestMock {}
+}));
+
+jest.mock('@sentry/nextjs', () => ({
+  startSpan: jest.fn((_context: unknown, callback: any) =>
+    callback({ setAttribute: jest.fn() })
+  ),
+  captureException: jest.fn()
+}));
+
+jest.mock('@/lib/providers/factory', () => ({
+  StockProviderFactory: {
+    getProvider: jest.fn()
+  }
+}));
+
+const mockGetProvider = StockProviderFactory.getProvider as jest.MockedFunction<
+  typeof StockProviderFactory.getProvider
+>;
+
+const mockProvider = {
+  healthCheck: jest.fn()
+};
+
+describe('/api/stocks/providers/health API Route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetProvider.mockReturnValue(mockProvider as any);
+  });
+
+  it('returns healthy provider status', async () => {
+    const health: ProviderHealthCheck = {
+      provider: 'Longbridge',
+      status: 'healthy',
+      latencyMs: 12,
+      checkedAt: '2024-01-01T00:00:00.000Z',
+      details: {
+        symbol: 'AAPL.US'
+      }
+    };
+    mockProvider.healthCheck.mockResolvedValue(health);
+
+    const response = await GET(
+      createMockRequest('http://localhost:3000/api/stocks/providers/health')
+    );
+    const responseData: APIResponse<ProviderHealthCheck> =
+      await response.json();
+
+    expect(response.status).toBe(200);
+    expect(responseData.success).toBe(true);
+    expect(responseData.data).toEqual(health);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(mockGetProvider).toHaveBeenCalledWith('longbridge');
+  });
+
+  it('returns degraded provider status', async () => {
+    const health: ProviderHealthCheck = {
+      provider: 'Longbridge',
+      status: 'degraded',
+      latencyMs: 8,
+      checkedAt: '2024-01-01T00:00:00.000Z',
+      details: {
+        code: 'NETWORK_ERROR',
+        message: 'Longbridge network request failed'
+      }
+    };
+    mockProvider.healthCheck.mockResolvedValue(health);
+
+    const response = await GET(
+      createMockRequest('http://localhost:3000/api/stocks/providers/health')
+    );
+    const responseData: APIResponse<ProviderHealthCheck> =
+      await response.json();
+
+    expect(response.status).toBe(200);
+    expect(responseData.data?.status).toBe('degraded');
+    expect(responseData.data?.details?.code).toBe('NETWORK_ERROR');
+  });
+
+  it('returns unconfigured provider status without leaking credentials', async () => {
+    process.env.LONGPORT_ACCESS_TOKEN = 'secret-token-for-health-route';
+    const health: ProviderHealthCheck = {
+      provider: 'Longbridge',
+      status: 'unconfigured',
+      latencyMs: 0,
+      checkedAt: '2024-01-01T00:00:00.000Z',
+      details: {
+        code: 'INVALID_API_KEY',
+        message: 'Longbridge credentials not configured'
+      }
+    };
+    mockProvider.healthCheck.mockResolvedValue(health);
+
+    const response = await GET(
+      createMockRequest('http://localhost:3000/api/stocks/providers/health')
+    );
+    const responseData: APIResponse<ProviderHealthCheck> =
+      await response.json();
+
+    expect(response.status).toBe(200);
+    expect(responseData.data?.status).toBe('unconfigured');
+    expect(JSON.stringify(responseData)).not.toContain(
+      'secret-token-for-health-route'
+    );
+  });
+});

--- a/src/app/api/stocks/providers/health/route.ts
+++ b/src/app/api/stocks/providers/health/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest } from 'next/server';
+import * as Sentry from '@sentry/nextjs';
+import { CANONICAL_QUOTE_PROVIDER } from '@/lib/providers/config';
+import { StockProviderFactory } from '@/lib/providers/factory';
+import {
+  createErrorResponse,
+  createSuccessResponse,
+  getStatusCodeForError,
+  isAPIError
+} from '@/lib/services/api-errors';
+import { logger } from '@/lib/logger';
+
+export async function GET(request: NextRequest) {
+  return Sentry.startSpan(
+    { op: 'http.server', name: 'GET /api/stocks/providers/health' },
+    async (span) => {
+      const requestPath = getRequestPath(request);
+      const providerName =
+        request.nextUrl?.searchParams.get('provider') ||
+        CANONICAL_QUOTE_PROVIDER;
+
+      span?.setAttribute('provider', providerName);
+      span?.setAttribute('path', requestPath);
+
+      try {
+        const provider = StockProviderFactory.getProvider(providerName);
+        const health = await provider.healthCheck();
+
+        span?.setAttribute('provider.status', health.status);
+
+        return createSuccessResponse(health, {
+          'Cache-Control': 'no-store'
+        });
+      } catch (error) {
+        Sentry.captureException(error);
+
+        if (isAPIError(error)) {
+          const statusCode = getStatusCodeForError(error.code);
+          const logContext = {
+            code: error.code,
+            path: requestPath,
+            originalError: error
+          };
+
+          if (statusCode >= 500) {
+            logger.error(
+              `Provider health API Error: ${error.message}`,
+              logContext
+            );
+          } else {
+            logger.warn(
+              `Provider health API Warning: ${error.message}`,
+              logContext
+            );
+          }
+
+          return createErrorResponse(error);
+        }
+
+        logger.error('Provider health API Unexpected Error', {
+          path: requestPath,
+          error
+        });
+
+        return createErrorResponse(
+          {
+            code: 'UNKNOWN_ERROR',
+            message: 'An unexpected error occurred'
+          },
+          500
+        );
+      }
+    }
+  );
+}
+
+function getRequestPath(request: NextRequest): string {
+  if (request?.nextUrl?.pathname) {
+    return request.nextUrl.pathname;
+  }
+
+  if (typeof request?.url === 'string') {
+    try {
+      return new URL(request.url).pathname;
+    } catch {
+      return 'unknown';
+    }
+  }
+
+  return 'unknown';
+}

--- a/src/app/api/stocks/quote/[symbol]/__tests__/route.test.ts
+++ b/src/app/api/stocks/quote/[symbol]/__tests__/route.test.ts
@@ -230,7 +230,10 @@ describe('/api/stocks/quote/[symbol] API Route', () => {
   it('maps API_LIMIT_EXCEEDED to 429', async () => {
     mockStockServiceInstance.getQuote.mockRejectedValue({
       code: 'API_LIMIT_EXCEEDED',
-      message: 'Rate limit'
+      message: 'Rate limit',
+      details: {
+        retryAfter: 7
+      }
     });
 
     const response = await GET(createMockRequest(), {
@@ -238,6 +241,7 @@ describe('/api/stocks/quote/[symbol] API Route', () => {
     });
 
     expect(response.status).toBe(429);
+    expect(response.headers.get('Retry-After')).toBe('7');
   });
 
   it('maps NETWORK_ERROR to 502', async () => {

--- a/src/app/api/stocks/quote/[symbol]/route.ts
+++ b/src/app/api/stocks/quote/[symbol]/route.ts
@@ -1,9 +1,15 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import * as Sentry from '@sentry/nextjs';
 import { CANONICAL_QUOTE_PROVIDER } from '@/lib/providers/config';
 import { getStockService } from '@/lib/services/stock-service';
+import {
+  createAPIError,
+  createErrorResponse,
+  createSuccessResponse,
+  getStatusCodeForError,
+  isAPIError
+} from '@/lib/services/api-errors';
 import { validateTicker, normalizeTicker } from '@/lib/validation/ticker';
-import { APIResponse, StockQuote, APIError } from '@/lib/types/stock-api';
 import { logger } from '@/lib/logger';
 
 export async function GET(
@@ -25,10 +31,10 @@ export async function GET(
         // Validate the ticker symbol
         const validation = validateTicker(symbol);
         if (!validation.isValid) {
-          const error: APIError = {
-            code: 'INVALID_SYMBOL',
-            message: validation.error || 'Invalid ticker symbol'
-          };
+          const error = createAPIError(
+            'INVALID_SYMBOL',
+            validation.error || 'Invalid ticker symbol'
+          );
 
           logger.warn(`API Error: ${error.message}`, {
             symbol: rawSymbol,
@@ -36,14 +42,7 @@ export async function GET(
             path: requestPath
           });
 
-          const response: APIResponse<null> = {
-            success: false,
-            data: null,
-            error,
-            timestamp: new Date().toISOString()
-          };
-
-          return NextResponse.json(response, { status: 400 });
+          return createErrorResponse(error, 400);
         }
 
         // Get the stock quote
@@ -54,19 +53,8 @@ export async function GET(
         const stockService = getStockService();
         const quote = await stockService.getQuote(symbol, provider);
 
-        // Return successful response
-        const response: APIResponse<StockQuote> = {
-          success: true,
-          data: quote,
-          error: null,
-          timestamp: new Date().toISOString()
-        };
-
-        return NextResponse.json(response, {
-          status: 200,
-          headers: {
-            'Cache-Control': 'public, s-maxage=10, stale-while-revalidate=30'
-          }
+        return createSuccessResponse(quote, {
+          'Cache-Control': 'public, s-maxage=10, stale-while-revalidate=30'
         });
       } catch (error) {
         Sentry.captureException(error);
@@ -87,14 +75,7 @@ export async function GET(
             logger.warn(`API Warning: ${error.message}`, logContext);
           }
 
-          const response: APIResponse<null> = {
-            success: false,
-            data: null,
-            error: error,
-            timestamp: new Date().toISOString()
-          };
-
-          return NextResponse.json(response, { status: statusCode });
+          return createErrorResponse(error);
         }
 
         // Handle unexpected errors
@@ -103,46 +84,16 @@ export async function GET(
           error
         });
 
-        const response: APIResponse<null> = {
-          success: false,
-          data: null,
-          error: {
+        return createErrorResponse(
+          {
             code: 'UNKNOWN_ERROR',
             message: 'An unexpected error occurred'
           },
-          timestamp: new Date().toISOString()
-        };
-
-        return NextResponse.json(response, { status: 500 });
+          500
+        );
       }
     }
   );
-}
-
-function isAPIError(error: unknown): error is APIError {
-  return (
-    error !== null &&
-    typeof error === 'object' &&
-    'code' in error &&
-    'message' in error
-  );
-}
-
-function getStatusCodeForError(code: string): number {
-  switch (code) {
-    case 'INVALID_SYMBOL':
-    case 'INVALID_PROVIDER':
-      return 400;
-    case 'API_LIMIT_EXCEEDED':
-      return 429;
-    case 'INVALID_API_KEY':
-      return 401;
-    case 'NETWORK_ERROR':
-      return 502;
-    case 'UNKNOWN_ERROR':
-    default:
-      return 500;
-  }
 }
 
 function getRequestPath(request: NextRequest): string {

--- a/src/lib/providers/__tests__/longbridge-request-guard.test.ts
+++ b/src/lib/providers/__tests__/longbridge-request-guard.test.ts
@@ -1,0 +1,147 @@
+import { LongbridgeRequestGuard } from '../longbridge-request-guard';
+
+function createDeferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('LongbridgeRequestGuard', () => {
+  it('limits concurrent operations and queues excess work', async () => {
+    let now = 0;
+    const sleepResolvers: Array<() => void> = [];
+    const sleep = jest.fn(
+      (ms: number) =>
+        new Promise<void>((resolve) => {
+          sleepResolvers.push(() => {
+            now += ms;
+            resolve();
+          });
+        })
+    );
+    const guard = new LongbridgeRequestGuard({
+      maxConcurrent: 2,
+      maxStartsPerWindow: 100,
+      queueTimeoutMs: 100,
+      concurrencyPollMs: 1,
+      now: () => now,
+      sleep
+    });
+    const first = createDeferred();
+    const second = createDeferred();
+    let active = 0;
+    let maxActive = 0;
+    let thirdStarted = false;
+
+    const runBlockingOperation = (
+      deferred: ReturnType<typeof createDeferred>
+    ) =>
+      guard.run(async () => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await deferred.promise;
+        active -= 1;
+      });
+
+    const firstRun = runBlockingOperation(first);
+    const secondRun = runBlockingOperation(second);
+    const thirdRun = guard.run(async () => {
+      thirdStarted = true;
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      active -= 1;
+    });
+
+    await flushPromises();
+
+    expect(active).toBe(2);
+    expect(thirdStarted).toBe(false);
+
+    first.resolve();
+    await flushPromises();
+    sleepResolvers.shift()?.();
+    await flushPromises();
+
+    expect(thirdStarted).toBe(true);
+    expect(maxActive).toBe(2);
+
+    second.resolve();
+    await Promise.all([firstRun, secondRun, thirdRun]);
+  });
+
+  it('limits operation starts per window', async () => {
+    let now = 0;
+    const sleep = jest.fn(async (ms: number) => {
+      now += ms;
+    });
+    const guard = new LongbridgeRequestGuard({
+      maxConcurrent: 10,
+      maxStartsPerWindow: 2,
+      windowMs: 1000,
+      now: () => now,
+      sleep
+    });
+
+    await guard.run(async () => 'first');
+    await guard.run(async () => 'second');
+    const startedAt = await guard.run(async () => now);
+
+    expect(sleep).toHaveBeenCalledWith(1000);
+    expect(startedAt).toBe(1000);
+  });
+
+  it('fails queued work when the queue is full', async () => {
+    let now = 0;
+    const sleepResolvers: Array<() => void> = [];
+    const sleep = jest.fn(
+      (ms: number) =>
+        new Promise<void>((resolve) => {
+          sleepResolvers.push(() => {
+            now += ms;
+            resolve();
+          });
+        })
+    );
+    const guard = new LongbridgeRequestGuard({
+      maxConcurrent: 1,
+      maxStartsPerWindow: 100,
+      queueLimit: 1,
+      queueTimeoutMs: 100,
+      now: () => now,
+      sleep
+    });
+    const first = createDeferred();
+
+    const firstRun = guard.run(async () => {
+      await first.promise;
+    });
+
+    await flushPromises();
+
+    const secondRun = guard.run(async () => undefined);
+    await flushPromises();
+
+    await expect(guard.run(async () => undefined)).rejects.toMatchObject({
+      code: 'API_LIMIT_EXCEEDED',
+      details: {
+        source: 'longbridge-request-guard',
+        reason: 'queue-full'
+      }
+    });
+
+    first.resolve();
+    await flushPromises();
+    sleepResolvers.shift()?.();
+    await Promise.all([firstRun, secondRun]);
+  });
+});

--- a/src/lib/providers/__tests__/longbridge.test.ts
+++ b/src/lib/providers/__tests__/longbridge.test.ts
@@ -1,11 +1,14 @@
 import { LongbridgeProvider } from '../longbridge';
+import { LongbridgeRequestGuard } from '../longbridge-request-guard';
 
 const mockCandlesticks = jest.fn();
+const mockConfigFromEnv = jest.fn(() => ({}));
+const mockQuote = jest.fn();
 const mockQuoteContextNew = jest.fn();
 
 jest.mock('longport', () => ({
   Config: {
-    fromEnv: jest.fn(() => ({}))
+    fromEnv: (...args: unknown[]) => mockConfigFromEnv(...args)
   },
   QuoteContext: {
     new: (...args: unknown[]) => mockQuoteContextNew(...args)
@@ -17,11 +20,35 @@ jest.mock('longport', () => ({
 
 jest.mock('../../logger', () => ({
   logger: {
-    error: jest.fn()
+    error: jest.fn(),
+    warn: jest.fn()
   }
 }));
 
-describe('LongbridgeProvider.getKLines', () => {
+const quoteFixture = {
+  symbol: 'AAPL.US',
+  timestamp: new Date('2024-01-02T15:30:00.000Z'),
+  lastDone: 105,
+  prevClose: 100,
+  volume: 1000,
+  high: 110,
+  low: 95,
+  open: 101
+};
+
+function createProvider(options: any = {}) {
+  return new LongbridgeProvider({
+    requestGuard: new LongbridgeRequestGuard({
+      maxConcurrent: 100,
+      maxStartsPerWindow: 1000,
+      sleep: async () => undefined
+    }),
+    sleep: async () => undefined,
+    ...options
+  });
+}
+
+describe('LongbridgeProvider', () => {
   const originalEnv = {
     LONGPORT_APP_KEY: process.env.LONGPORT_APP_KEY,
     LONGPORT_APP_SECRET: process.env.LONGPORT_APP_SECRET,
@@ -33,10 +60,14 @@ describe('LongbridgeProvider.getKLines', () => {
     process.env.LONGPORT_APP_SECRET = 'app-secret';
     process.env.LONGPORT_ACCESS_TOKEN = 'token';
 
+    LongbridgeProvider.clearHealthCacheForTests();
     mockCandlesticks.mockReset();
+    mockConfigFromEnv.mockClear();
+    mockQuote.mockReset();
     mockQuoteContextNew.mockReset();
     mockQuoteContextNew.mockResolvedValue({
-      candlesticks: mockCandlesticks
+      candlesticks: mockCandlesticks,
+      quote: mockQuote
     });
   });
 
@@ -46,46 +77,204 @@ describe('LongbridgeProvider.getKLines', () => {
     process.env.LONGPORT_ACCESS_TOKEN = originalEnv.LONGPORT_ACCESS_TOKEN;
   });
 
-  it.each([
-    ['day', 14],
-    ['week', 15],
-    ['month', 16],
-    ['year', 18]
-  ] as const)(
-    'maps the %s interval to Longbridge period %i',
-    async (interval, expectedPeriod) => {
-      mockCandlesticks.mockResolvedValue([
-        {
-          timestamp: new Date('2024-01-02T00:00:00.000Z'),
-          open: 100,
-          high: 110,
-          low: 95,
-          close: 105,
-          volume: 1000
-        }
-      ]);
+  describe('getQuote', () => {
+    it('returns a transformed quote', async () => {
+      mockQuote.mockResolvedValue([quoteFixture]);
 
-      const provider = new LongbridgeProvider();
-      const series = await provider.getKLines('AAPL', interval);
+      const quote = await createProvider().getQuote('AAPL');
 
-      expect(mockCandlesticks).toHaveBeenCalledWith(
-        'AAPL.US',
-        expectedPeriod,
-        1000,
-        1,
-        1
+      expect(mockQuote).toHaveBeenCalledWith(['AAPL.US']);
+      expect(quote).toEqual(
+        expect.objectContaining({
+          symbol: 'AAPL.US',
+          price: 105,
+          change: 5,
+          changePercent: 5,
+          previousClose: 100,
+          lastUpdated: '2024-01-02T15:30:00.000Z'
+        })
       );
-      expect(series.range.interval).toBe(interval);
-      expect(series.symbol).toBe('AAPL');
-    }
-  );
+    });
 
-  it('defaults to the day interval when none is provided', async () => {
-    mockCandlesticks.mockResolvedValue([]);
+    it('throws INVALID_API_KEY when credentials are missing', async () => {
+      delete process.env.LONGPORT_APP_KEY;
 
-    const provider = new LongbridgeProvider();
-    await provider.getKLines('AAPL');
+      await expect(createProvider().getQuote('AAPL')).rejects.toEqual({
+        code: 'INVALID_API_KEY',
+        message: 'Longbridge credentials not configured'
+      });
+      expect(mockQuoteContextNew).not.toHaveBeenCalled();
+    });
 
-    expect(mockCandlesticks).toHaveBeenCalledWith('AAPL.US', 14, 1000, 1, 1);
+    it('maps empty quote responses to INVALID_SYMBOL', async () => {
+      mockQuote.mockResolvedValue([]);
+
+      await expect(createProvider().getQuote('BAD')).rejects.toEqual({
+        code: 'INVALID_SYMBOL',
+        message: 'No quote data found for symbol: BAD'
+      });
+      expect(mockQuote).toHaveBeenCalledTimes(1);
+    });
+
+    it('maps persistent Longbridge rate limits and preserves retryAfter', async () => {
+      const rateLimitError = Object.assign(new Error('rate limit exceeded'), {
+        status: 429,
+        headers: {
+          get: (name: string) => (name === 'retry-after' ? '2' : undefined)
+        }
+      });
+      mockQuote.mockRejectedValue(rateLimitError);
+
+      await expect(
+        createProvider({ maxAttempts: 2 }).getQuote('AAPL')
+      ).rejects.toMatchObject({
+        code: 'API_LIMIT_EXCEEDED',
+        details: {
+          retryAfter: 2
+        }
+      });
+      expect(mockQuote).toHaveBeenCalledTimes(2);
+    });
+
+    it('maps network timeouts to NETWORK_ERROR', async () => {
+      const timeoutError = Object.assign(new Error('connect ETIMEDOUT'), {
+        code: 'ETIMEDOUT'
+      });
+      mockQuote.mockRejectedValue(timeoutError);
+
+      await expect(
+        createProvider({ maxAttempts: 1 }).getQuote('AAPL')
+      ).rejects.toMatchObject({
+        code: 'NETWORK_ERROR',
+        message: 'Longbridge network request failed'
+      });
+      expect(mockQuote).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries transient failures and returns a successful quote', async () => {
+      const resetError = Object.assign(new Error('socket hang up'), {
+        code: 'ECONNRESET'
+      });
+      const sleep = jest.fn(async () => undefined);
+
+      mockQuote
+        .mockRejectedValueOnce(resetError)
+        .mockResolvedValueOnce([quoteFixture]);
+
+      const quote = await createProvider({ sleep }).getQuote('AAPL');
+
+      expect(quote.price).toBe(105);
+      expect(mockQuote).toHaveBeenCalledTimes(2);
+      expect(sleep).toHaveBeenCalledWith(250);
+    });
+
+    it('does not retry invalid symbol SDK failures', async () => {
+      mockQuote.mockRejectedValue(new Error('invalid symbol'));
+
+      await expect(createProvider().getQuote('BAD')).rejects.toMatchObject({
+        code: 'INVALID_SYMBOL'
+      });
+      expect(mockQuote).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not retry authentication failures', async () => {
+      const authError = Object.assign(new Error('invalid access token'), {
+        status: 401
+      });
+      mockQuote.mockRejectedValue(authError);
+
+      await expect(createProvider().getQuote('AAPL')).rejects.toMatchObject({
+        code: 'INVALID_API_KEY'
+      });
+      expect(mockQuote).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getKLines', () => {
+    it.each([
+      ['day', 14],
+      ['week', 15],
+      ['month', 16],
+      ['year', 18]
+    ] as const)(
+      'maps the %s interval to Longbridge period %i',
+      async (interval, expectedPeriod) => {
+        mockCandlesticks.mockResolvedValue([
+          {
+            timestamp: new Date('2024-01-02T00:00:00.000Z'),
+            open: 100,
+            high: 110,
+            low: 95,
+            close: 105,
+            volume: 1000
+          }
+        ]);
+
+        const series = await createProvider().getKLines('AAPL', interval);
+
+        expect(mockCandlesticks).toHaveBeenCalledWith(
+          'AAPL.US',
+          expectedPeriod,
+          1000,
+          1,
+          1
+        );
+        expect(series.range.interval).toBe(interval);
+        expect(series.symbol).toBe('AAPL');
+      }
+    );
+
+    it('defaults to the day interval when none is provided', async () => {
+      mockCandlesticks.mockResolvedValue([]);
+
+      await createProvider().getKLines('AAPL');
+
+      expect(mockCandlesticks).toHaveBeenCalledWith('AAPL.US', 14, 1000, 1, 1);
+    });
+  });
+
+  describe('healthCheck', () => {
+    it('returns healthy status and caches the live probe inside the TTL', async () => {
+      mockQuote.mockResolvedValue([quoteFixture]);
+      let now = Date.parse('2024-01-02T00:00:00.000Z');
+      const provider = createProvider({
+        healthCacheTtlMs: 1000,
+        now: () => now
+      });
+
+      const first = await provider.healthCheck();
+      now += 500;
+      const second = await provider.healthCheck();
+
+      expect(first.status).toBe('healthy');
+      expect(second).toBe(first);
+      expect(mockQuote).toHaveBeenCalledTimes(1);
+      expect(mockQuote).toHaveBeenCalledWith(['AAPL.US']);
+    });
+
+    it('returns degraded status for network failures', async () => {
+      mockQuote.mockRejectedValue(new Error('gateway timeout'));
+
+      const health = await createProvider().healthCheck();
+
+      expect(health.status).toBe('degraded');
+      expect(health.details).toEqual(
+        expect.objectContaining({
+          code: 'NETWORK_ERROR',
+          message: 'Longbridge network request failed'
+        })
+      );
+    });
+
+    it('returns unconfigured status without leaking credential values', async () => {
+      process.env.LONGPORT_ACCESS_TOKEN = 'secret-access-token';
+      delete process.env.LONGPORT_APP_KEY;
+
+      const health = await createProvider().healthCheck();
+
+      expect(health.status).toBe('unconfigured');
+      expect(JSON.stringify(health)).not.toContain('secret-access-token');
+      expect(mockQuoteContextNew).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/lib/providers/longbridge-errors.ts
+++ b/src/lib/providers/longbridge-errors.ts
@@ -1,0 +1,357 @@
+import { APIError, APIErrorCode } from '../types/stock-api';
+
+const SECRET_ENV_KEYS = [
+  'LONGPORT_APP_KEY',
+  'LONGPORT_APP_SECRET',
+  'LONGPORT_ACCESS_TOKEN'
+] as const;
+
+const NETWORK_ERROR_CODES = [
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'ETIMEDOUT',
+  'ESOCKETTIMEDOUT',
+  'ECONNABORTED'
+];
+
+const API_ERROR_CODES = new Set<string>([
+  'INVALID_SYMBOL',
+  'INVALID_INTERVAL',
+  'INVALID_PROVIDER',
+  'API_LIMIT_EXCEEDED',
+  'NETWORK_ERROR',
+  'INVALID_API_KEY',
+  'UNKNOWN_ERROR'
+]);
+
+export interface NormalizedLongbridgeError {
+  error: APIError;
+  retryable: boolean;
+  retryAfter?: number;
+}
+
+export function normalizeLongbridgeError(
+  error: unknown,
+  fallbackMessage: string
+): NormalizedLongbridgeError {
+  if (isAPIError(error)) {
+    const retryAfter = normalizeRetryAfter(error.details?.retryAfter);
+    const isGuardLimit = error.details?.source === 'longbridge-request-guard';
+
+    return {
+      error,
+      retryable:
+        !isGuardLimit &&
+        (error.code === 'API_LIMIT_EXCEEDED' || error.code === 'NETWORK_ERROR'),
+      retryAfter
+    };
+  }
+
+  const statusCode = getStatusCode(error);
+  const providerCode = getProviderCode(error);
+  const message = getErrorMessage(error);
+  const normalizedMessage = message.toLowerCase();
+  const retryAfter = getRetryAfter(error);
+
+  let code: APIErrorCode = 'UNKNOWN_ERROR';
+  let apiMessage = fallbackMessage;
+  let retryable = false;
+
+  if (isAuthError(normalizedMessage, statusCode)) {
+    code = 'INVALID_API_KEY';
+    apiMessage = 'Longbridge authentication failed';
+  } else if (isRateLimitError(normalizedMessage, statusCode)) {
+    code = 'API_LIMIT_EXCEEDED';
+    apiMessage = 'Longbridge rate limit exceeded. Please try again shortly.';
+    retryable = true;
+  } else if (isInvalidSymbolError(normalizedMessage, statusCode)) {
+    code = 'INVALID_SYMBOL';
+    apiMessage = 'Longbridge symbol was not found or is unsupported';
+  } else if (isNetworkError(normalizedMessage, statusCode, providerCode)) {
+    code = 'NETWORK_ERROR';
+    apiMessage = 'Longbridge network request failed';
+    retryable = true;
+  }
+
+  const details = createSafeDetails(error, retryAfter);
+
+  return {
+    error: {
+      code,
+      message: apiMessage,
+      details
+    },
+    retryable,
+    retryAfter
+  };
+}
+
+export function sanitizeLongbridgeAPIError(error: APIError): APIError {
+  return {
+    code: error.code,
+    message: redactSecrets(error.message),
+    details: sanitizeDetails(error.details)
+  };
+}
+
+function isAuthError(message: string, statusCode?: number): boolean {
+  return (
+    statusCode === 401 ||
+    statusCode === 403 ||
+    message.includes('unauthorized') ||
+    message.includes('forbidden') ||
+    message.includes('permission') ||
+    message.includes('invalid token') ||
+    message.includes('access token') ||
+    message.includes('app key') ||
+    message.includes('app secret') ||
+    message.includes('auth')
+  );
+}
+
+function isRateLimitError(message: string, statusCode?: number): boolean {
+  return (
+    statusCode === 429 ||
+    message.includes('rate limit') ||
+    message.includes('too many request') ||
+    message.includes('frequency') ||
+    message.includes('quota') ||
+    (message.includes('limit') && message.includes('exceed'))
+  );
+}
+
+function isInvalidSymbolError(message: string, statusCode?: number): boolean {
+  return (
+    statusCode === 404 ||
+    message.includes('invalid symbol') ||
+    message.includes('symbol not found') ||
+    message.includes('security not found') ||
+    message.includes('unsupported symbol') ||
+    message.includes('unknown symbol')
+  );
+}
+
+function isNetworkError(
+  message: string,
+  statusCode?: number,
+  providerCode?: string
+): boolean {
+  return (
+    (typeof statusCode === 'number' && statusCode >= 500) ||
+    NETWORK_ERROR_CODES.some((code) => providerCode === code) ||
+    NETWORK_ERROR_CODES.some((code) => message.includes(code.toLowerCase())) ||
+    message.includes('network') ||
+    message.includes('timeout') ||
+    message.includes('timed out') ||
+    message.includes('socket') ||
+    message.includes('aborted') ||
+    message.includes('temporarily unavailable') ||
+    message.includes('bad gateway') ||
+    message.includes('service unavailable') ||
+    message.includes('gateway timeout')
+  );
+}
+
+function createSafeDetails(
+  error: unknown,
+  retryAfter?: number
+): Record<string, unknown> {
+  const details: Record<string, unknown> = {
+    provider: 'longbridge'
+  };
+  const upstream = getUpstreamDetails(error);
+
+  if (Object.keys(upstream).length > 0) {
+    details.upstream = upstream;
+  }
+
+  if (retryAfter) {
+    details.retryAfter = retryAfter;
+  }
+
+  return details;
+}
+
+function getUpstreamDetails(error: unknown): Record<string, unknown> {
+  const record = asRecord(error);
+  const details: Record<string, unknown> = {};
+  const name = getStringField(record, 'name');
+  const code = getProviderCode(error);
+  const statusCode = getStatusCode(error);
+  const message = getErrorMessage(error);
+
+  if (name) {
+    details.name = redactSecrets(name);
+  }
+
+  if (code) {
+    details.code = redactSecrets(code);
+  }
+
+  if (statusCode) {
+    details.statusCode = statusCode;
+  }
+
+  if (message) {
+    details.message = redactSecrets(message);
+  }
+
+  return details;
+}
+
+function sanitizeDetails(
+  details?: Record<string, unknown>
+): Record<string, unknown> | undefined {
+  if (!details) {
+    return undefined;
+  }
+
+  return JSON.parse(
+    JSON.stringify(details, (_key, value) => {
+      if (typeof value === 'string') {
+        return redactSecrets(value);
+      }
+
+      return value;
+    })
+  );
+}
+
+function redactSecrets(value: string): string {
+  return SECRET_ENV_KEYS.reduce((redacted, key) => {
+    const secret = process.env[key];
+
+    if (!secret) {
+      return redacted;
+    }
+
+    return redacted.split(secret).join('[redacted]');
+  }, value);
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  const record = asRecord(error);
+  return getStringField(record, 'message') ?? '';
+}
+
+function getProviderCode(error: unknown): string | undefined {
+  const record = asRecord(error);
+  const code = getStringField(record, 'code');
+
+  if (code) {
+    return code;
+  }
+
+  const cause = asRecord(record?.cause);
+  return getStringField(cause, 'code');
+}
+
+function getStatusCode(error: unknown): number | undefined {
+  const record = asRecord(error);
+  const response = asRecord(record?.response);
+
+  return (
+    getNumberField(record, 'status') ??
+    getNumberField(record, 'statusCode') ??
+    getNumberField(response, 'status') ??
+    getNumberField(response, 'statusCode')
+  );
+}
+
+function getRetryAfter(error: unknown): number | undefined {
+  const record = asRecord(error);
+  const response = asRecord(record?.response);
+
+  return (
+    normalizeRetryAfter(record?.retryAfter) ??
+    normalizeRetryAfter(record?.retry_after) ??
+    normalizeRetryAfter(getHeader(record?.headers, 'retry-after')) ??
+    normalizeRetryAfter(getHeader(response?.headers, 'retry-after'))
+  );
+}
+
+function getHeader(headers: unknown, key: string): unknown {
+  if (!headers) {
+    return undefined;
+  }
+
+  if (
+    typeof headers === 'object' &&
+    'get' in headers &&
+    typeof (headers as { get: (name: string) => unknown }).get === 'function'
+  ) {
+    return (headers as { get: (name: string) => unknown }).get(key);
+  }
+
+  const record = asRecord(headers);
+  return (
+    record?.[key] ?? record?.[key.toLowerCase()] ?? record?.[key.toUpperCase()]
+  );
+}
+
+function normalizeRetryAfter(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return Math.ceil(value);
+  }
+
+  if (typeof value !== 'string' || !value.trim()) {
+    return undefined;
+  }
+
+  const numericValue = Number(value);
+  if (Number.isFinite(numericValue) && numericValue > 0) {
+    return Math.ceil(numericValue);
+  }
+
+  const dateValue = Date.parse(value);
+  if (!Number.isNaN(dateValue)) {
+    const seconds = Math.ceil((dateValue - Date.now()) / 1000);
+    return seconds > 0 ? seconds : undefined;
+  }
+
+  return undefined;
+}
+
+function getStringField(
+  record: Record<string, unknown> | undefined,
+  key: string
+): string | undefined {
+  const value = record?.[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function getNumberField(
+  record: Record<string, unknown> | undefined,
+  key: string
+): number | undefined {
+  const value = record?.[key];
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === 'object'
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function isAPIError(error: unknown): error is APIError {
+  const record = asRecord(error);
+
+  return (
+    typeof record?.code === 'string' &&
+    API_ERROR_CODES.has(record.code) &&
+    typeof record?.message === 'string'
+  );
+}

--- a/src/lib/providers/longbridge-request-guard.ts
+++ b/src/lib/providers/longbridge-request-guard.ts
@@ -1,0 +1,133 @@
+import { APIError } from '../types/stock-api';
+
+type SleepFn = (ms: number) => Promise<void>;
+
+export interface LongbridgeRequestGuardOptions {
+  maxConcurrent?: number;
+  maxStartsPerWindow?: number;
+  windowMs?: number;
+  queueLimit?: number;
+  queueTimeoutMs?: number;
+  concurrencyPollMs?: number;
+  now?: () => number;
+  sleep?: SleepFn;
+}
+
+const DEFAULT_OPTIONS = {
+  maxConcurrent: 5,
+  maxStartsPerWindow: 10,
+  windowMs: 1000,
+  queueLimit: 50,
+  queueTimeoutMs: 2000,
+  concurrencyPollMs: 10
+};
+
+export class LongbridgeRequestGuard {
+  private activeCount = 0;
+  private waitingCount = 0;
+  private starts: number[] = [];
+  private readonly maxConcurrent: number;
+  private readonly maxStartsPerWindow: number;
+  private readonly windowMs: number;
+  private readonly queueLimit: number;
+  private readonly queueTimeoutMs: number;
+  private readonly concurrencyPollMs: number;
+  private readonly now: () => number;
+  private readonly sleep: SleepFn;
+
+  constructor(options: LongbridgeRequestGuardOptions = {}) {
+    this.maxConcurrent = options.maxConcurrent ?? DEFAULT_OPTIONS.maxConcurrent;
+    this.maxStartsPerWindow =
+      options.maxStartsPerWindow ?? DEFAULT_OPTIONS.maxStartsPerWindow;
+    this.windowMs = options.windowMs ?? DEFAULT_OPTIONS.windowMs;
+    this.queueLimit = options.queueLimit ?? DEFAULT_OPTIONS.queueLimit;
+    this.queueTimeoutMs =
+      options.queueTimeoutMs ?? DEFAULT_OPTIONS.queueTimeoutMs;
+    this.concurrencyPollMs =
+      options.concurrencyPollMs ?? DEFAULT_OPTIONS.concurrencyPollMs;
+    this.now = options.now ?? Date.now;
+    this.sleep =
+      options.sleep ??
+      ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
+  }
+
+  async run<T>(operation: () => Promise<T>): Promise<T> {
+    await this.acquire();
+
+    try {
+      return await operation();
+    } finally {
+      this.activeCount -= 1;
+    }
+  }
+
+  private async acquire(): Promise<void> {
+    if (this.waitingCount >= this.queueLimit) {
+      throw createRequestGuardLimitError(
+        Math.ceil(this.queueTimeoutMs / 1000),
+        'queue-full'
+      );
+    }
+
+    this.waitingCount += 1;
+    const deadline = this.now() + this.queueTimeoutMs;
+
+    try {
+      while (true) {
+        const now = this.now();
+        const waitMs = this.getWaitMs(now);
+
+        if (waitMs === 0) {
+          this.activeCount += 1;
+          this.starts.push(now);
+          return;
+        }
+
+        if (now + waitMs > deadline) {
+          throw createRequestGuardLimitError(
+            Math.max(1, Math.ceil((deadline - now) / 1000)),
+            'queue-timeout'
+          );
+        }
+
+        await this.sleep(waitMs);
+      }
+    } finally {
+      this.waitingCount -= 1;
+    }
+  }
+
+  private getWaitMs(now: number): number {
+    this.starts = this.starts.filter(
+      (startedAt) => now - startedAt < this.windowMs
+    );
+
+    if (this.activeCount >= this.maxConcurrent) {
+      return this.concurrencyPollMs;
+    }
+
+    if (this.starts.length >= this.maxStartsPerWindow) {
+      return Math.max(1, this.windowMs - (now - this.starts[0]));
+    }
+
+    return 0;
+  }
+}
+
+export const longbridgeRequestGuard = new LongbridgeRequestGuard();
+
+function createRequestGuardLimitError(
+  retryAfter: number,
+  reason: 'queue-full' | 'queue-timeout'
+): APIError {
+  return {
+    code: 'API_LIMIT_EXCEEDED',
+    message:
+      'Longbridge request rate limit exceeded. Please try again shortly.',
+    details: {
+      retryAfter,
+      source: 'longbridge-request-guard',
+      reason
+    }
+  };
+}

--- a/src/lib/providers/longbridge.ts
+++ b/src/lib/providers/longbridge.ts
@@ -8,7 +8,7 @@ import {
   TimeRange
 } from '../types/stock-api';
 import { logger } from '../logger';
-import { StockDataProvider } from './types';
+import { ProviderHealthCheck, StockDataProvider } from './types';
 import {
   Config,
   QuoteContext,
@@ -17,8 +17,21 @@ import {
   AdjustType,
   TradeSessions
 } from 'longport';
+import {
+  normalizeLongbridgeError,
+  sanitizeLongbridgeAPIError
+} from './longbridge-errors';
+import {
+  longbridgeRequestGuard,
+  LongbridgeRequestGuard
+} from './longbridge-request-guard';
 
 const LONG_BRIDGE_KLINE_COUNT = 1000;
+const LONG_BRIDGE_MAX_ATTEMPTS = 3;
+const LONG_BRIDGE_RETRY_BASE_DELAY_MS = 250;
+const LONG_BRIDGE_RETRY_MAX_DELAY_MS = 2000;
+const LONG_BRIDGE_HEALTH_CACHE_TTL_MS = 30_000;
+const LONG_BRIDGE_HEALTH_SYMBOL = 'AAPL.US';
 
 // Longbridge exposes const-enum Period values where 17 is Quarter and 18 is Year.
 const LONG_BRIDGE_PERIOD_MAP: Record<KLineInterval, number> = {
@@ -28,130 +41,310 @@ const LONG_BRIDGE_PERIOD_MAP: Record<KLineInterval, number> = {
   year: 18
 };
 
+interface LongbridgeProviderOptions {
+  requestGuard?: LongbridgeRequestGuard;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+  maxAttempts?: number;
+  healthCacheTtlMs?: number;
+  healthSymbol?: string;
+}
+
+interface ExecuteOptions {
+  maxAttempts?: number;
+  logLabel: string;
+}
+
 export class LongbridgeProvider implements StockDataProvider {
   name = 'Longbridge';
+  private static healthCache:
+    | {
+        expiresAt: number;
+        value: ProviderHealthCheck;
+      }
+    | undefined;
+  private static healthInFlight: Promise<ProviderHealthCheck> | undefined;
+
+  private readonly requestGuard: LongbridgeRequestGuard;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private readonly now: () => number;
+  private readonly maxAttempts: number;
+  private readonly healthCacheTtlMs: number;
+  private readonly healthSymbol: string;
+
+  constructor(options: LongbridgeProviderOptions = {}) {
+    this.requestGuard = options.requestGuard ?? longbridgeRequestGuard;
+    this.sleep =
+      options.sleep ??
+      ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
+    this.now = options.now ?? Date.now;
+    this.maxAttempts = options.maxAttempts ?? LONG_BRIDGE_MAX_ATTEMPTS;
+    this.healthCacheTtlMs =
+      options.healthCacheTtlMs ?? LONG_BRIDGE_HEALTH_CACHE_TTL_MS;
+    this.healthSymbol = options.healthSymbol ?? LONG_BRIDGE_HEALTH_SYMBOL;
+  }
 
   async getQuote(symbol: string): Promise<StockQuote> {
-    if (
-      !process.env.LONGPORT_APP_KEY ||
-      !process.env.LONGPORT_APP_SECRET ||
-      !process.env.LONGPORT_ACCESS_TOKEN
-    ) {
-      throw {
-        code: 'INVALID_API_KEY',
-        message: 'Longbridge credentials not configured'
-      } as APIError;
-    }
+    this.ensureConfigured();
 
-    try {
-      const config = Config.fromEnv();
-      const context = await QuoteContext.new(config);
+    return this.executeWithResilience(
+      async () => {
+        const config = Config.fromEnv();
+        const context = await QuoteContext.new(config);
 
-      const longbridgeSymbol = this.normalizeSymbol(symbol);
-      const quote = await context.quote([longbridgeSymbol]);
+        const longbridgeSymbol = this.normalizeSymbol(symbol);
+        const quote = await context.quote([longbridgeSymbol]);
 
-      if (!quote || quote.length === 0) {
-        throw {
-          code: 'INVALID_SYMBOL',
-          message: `No quote data found for symbol: ${symbol}`
-        } as APIError;
-      }
+        if (!quote || quote.length === 0) {
+          throw {
+            code: 'INVALID_SYMBOL',
+            message: `No quote data found for symbol: ${symbol}`
+          } as APIError;
+        }
 
-      const q = quote[0];
-      const lastUpdated = q.timestamp
-        ? q.timestamp.toISOString()
-        : new Date().toISOString();
+        const q = quote[0];
+        const lastUpdated = q.timestamp
+          ? q.timestamp.toISOString()
+          : new Date().toISOString();
 
-      const price = Number(q.lastDone);
-      const prevClose = Number(q.prevClose);
-      const change = price - prevClose;
-      const changePercent = prevClose !== 0 ? (change / prevClose) * 100 : 0;
+        const price = Number(q.lastDone);
+        const prevClose = Number(q.prevClose);
+        const change = price - prevClose;
+        const changePercent = prevClose !== 0 ? (change / prevClose) * 100 : 0;
 
-      return {
-        symbol: q.symbol,
-        name: q.symbol,
-        price: price,
-        change: change,
-        changePercent: changePercent,
-        volume: Number(q.volume),
-        high: Number(q.high),
-        low: Number(q.low),
-        open: Number(q.open),
-        previousClose: prevClose,
-        marketCap: null,
-        peRatio: null,
-        eps: null,
-        dividendYield: null,
-        week52High: null,
-        week52Low: null,
-        avgVolume: null,
-        beta: null,
-        lastUpdated: lastUpdated
-      };
-    } catch (error) {
-      logger.error('Longbridge Quote Error', { error });
-
-      if (this.isAPIError(error)) {
-        throw error;
-      }
-
-      const apiError: APIError = {
-        code: 'UNKNOWN_ERROR',
-        message: 'Failed to fetch stock quote from Longbridge',
-        details: { originalError: error }
-      };
-      throw apiError;
-    }
+        return {
+          symbol: q.symbol,
+          name: q.symbol,
+          price: price,
+          change: change,
+          changePercent: changePercent,
+          volume: Number(q.volume),
+          high: Number(q.high),
+          low: Number(q.low),
+          open: Number(q.open),
+          previousClose: prevClose,
+          marketCap: null,
+          peRatio: null,
+          eps: null,
+          dividendYield: null,
+          week52High: null,
+          week52Low: null,
+          avgVolume: null,
+          beta: null,
+          lastUpdated: lastUpdated
+        };
+      },
+      'Failed to fetch stock quote from Longbridge',
+      { logLabel: 'Longbridge Quote Error' }
+    );
   }
 
   async getKLines(
     symbol: string,
     interval: KLineInterval = DEFAULT_KLINE_INTERVAL
   ): Promise<KLineSeries> {
-    if (
-      !process.env.LONGPORT_APP_KEY ||
-      !process.env.LONGPORT_APP_SECRET ||
-      !process.env.LONGPORT_ACCESS_TOKEN
-    ) {
+    this.ensureConfigured();
+
+    return this.executeWithResilience(
+      async () => {
+        const config = Config.fromEnv();
+        const context = await QuoteContext.new(config);
+
+        const longbridgeSymbol = this.normalizeSymbol(symbol);
+
+        // Fetch candles using numeric values to avoid isolatedModules const enum issues.
+        const period = LONG_BRIDGE_PERIOD_MAP[interval];
+        // AdjustType.ForwardAdjust = 1
+        // TradeSessions.All = 1
+        const candlesData = await context.candlesticks(
+          longbridgeSymbol,
+          period as unknown as Period,
+          LONG_BRIDGE_KLINE_COUNT,
+          1 as unknown as AdjustType,
+          1 as unknown as TradeSessions
+        );
+
+        return this.transformCandlesticksToSeries(
+          candlesData,
+          symbol,
+          interval
+        );
+      },
+      'Failed to fetch kline series from Longbridge',
+      { logLabel: 'Longbridge KLine Error' }
+    );
+  }
+
+  async healthCheck(): Promise<ProviderHealthCheck> {
+    const now = this.now();
+    const cached = LongbridgeProvider.healthCache;
+
+    if (cached && cached.expiresAt > now) {
+      return cached.value;
+    }
+
+    if (LongbridgeProvider.healthInFlight) {
+      return LongbridgeProvider.healthInFlight;
+    }
+
+    LongbridgeProvider.healthInFlight = this.performHealthCheck().then(
+      (health) => {
+        LongbridgeProvider.healthCache = {
+          value: health,
+          expiresAt: this.now() + this.healthCacheTtlMs
+        };
+        return health;
+      }
+    );
+
+    try {
+      return await LongbridgeProvider.healthInFlight;
+    } finally {
+      LongbridgeProvider.healthInFlight = undefined;
+    }
+  }
+
+  static clearHealthCacheForTests(): void {
+    LongbridgeProvider.healthCache = undefined;
+    LongbridgeProvider.healthInFlight = undefined;
+  }
+
+  private async performHealthCheck(): Promise<ProviderHealthCheck> {
+    const startedAt = this.now();
+    const checkedAt = new Date(startedAt).toISOString();
+
+    if (!this.hasCredentials()) {
+      return {
+        provider: this.name,
+        status: 'unconfigured',
+        latencyMs: 0,
+        checkedAt,
+        details: {
+          code: 'INVALID_API_KEY',
+          message: 'Longbridge credentials not configured'
+        }
+      };
+    }
+
+    try {
+      await this.executeWithResilience(
+        async () => {
+          const config = Config.fromEnv();
+          const context = await QuoteContext.new(config);
+          const quote = await context.quote([this.healthSymbol]);
+
+          if (!quote || quote.length === 0) {
+            throw {
+              code: 'INVALID_SYMBOL',
+              message: `No quote data found for symbol: ${this.healthSymbol}`
+            } as APIError;
+          }
+        },
+        'Longbridge health check failed',
+        {
+          maxAttempts: 1,
+          logLabel: 'Longbridge Health Check Error'
+        }
+      );
+
+      return {
+        provider: this.name,
+        status: 'healthy',
+        latencyMs: Math.max(0, this.now() - startedAt),
+        checkedAt,
+        details: {
+          symbol: this.healthSymbol
+        }
+      };
+    } catch (error) {
+      const apiError = this.isAPIError(error)
+        ? sanitizeLongbridgeAPIError(error)
+        : normalizeLongbridgeError(error, 'Longbridge health check failed')
+            .error;
+
+      return {
+        provider: this.name,
+        status:
+          apiError.code === 'INVALID_API_KEY' ? 'unconfigured' : 'degraded',
+        latencyMs: Math.max(0, this.now() - startedAt),
+        checkedAt,
+        details: {
+          code: apiError.code,
+          message: apiError.message,
+          retryAfter:
+            typeof apiError.details?.retryAfter === 'number'
+              ? apiError.details.retryAfter
+              : undefined
+        }
+      };
+    }
+  }
+
+  private async executeWithResilience<T>(
+    operation: () => Promise<T>,
+    fallbackMessage: string,
+    options: ExecuteOptions
+  ): Promise<T> {
+    const maxAttempts = options.maxAttempts ?? this.maxAttempts;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      try {
+        return await this.requestGuard.run(operation);
+      } catch (error) {
+        const normalized = normalizeLongbridgeError(error, fallbackMessage);
+        const shouldRetry = normalized.retryable && attempt < maxAttempts;
+
+        if (!shouldRetry) {
+          logger.error(options.logLabel, {
+            error: normalized.error,
+            attempt,
+            maxAttempts
+          });
+          throw normalized.error;
+        }
+
+        logger.warn('Longbridge transient failure; retrying', {
+          code: normalized.error.code,
+          attempt,
+          maxAttempts
+        });
+
+        await this.sleep(this.getRetryDelayMs(attempt, normalized.retryAfter));
+      }
+    }
+
+    throw {
+      code: 'UNKNOWN_ERROR',
+      message: fallbackMessage
+    } as APIError;
+  }
+
+  private getRetryDelayMs(attempt: number, retryAfter?: number): number {
+    if (retryAfter) {
+      return Math.min(retryAfter * 1000, LONG_BRIDGE_RETRY_MAX_DELAY_MS);
+    }
+
+    return Math.min(
+      LONG_BRIDGE_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1),
+      LONG_BRIDGE_RETRY_MAX_DELAY_MS
+    );
+  }
+
+  private ensureConfigured(): void {
+    if (!this.hasCredentials()) {
       throw {
         code: 'INVALID_API_KEY',
         message: 'Longbridge credentials not configured'
       } as APIError;
     }
+  }
 
-    try {
-      const config = Config.fromEnv();
-      const context = await QuoteContext.new(config);
-
-      const longbridgeSymbol = this.normalizeSymbol(symbol);
-
-      // Fetch candles using numeric values to avoid isolatedModules const enum issues.
-      const period = LONG_BRIDGE_PERIOD_MAP[interval];
-      // AdjustType.ForwardAdjust = 1
-      // TradeSessions.All = 1
-      const candlesData = await context.candlesticks(
-        longbridgeSymbol,
-        period as unknown as Period,
-        LONG_BRIDGE_KLINE_COUNT,
-        1 as unknown as AdjustType,
-        1 as unknown as TradeSessions
-      );
-
-      return this.transformCandlesticksToSeries(candlesData, symbol, interval);
-    } catch (error) {
-      logger.error('Longbridge KLine Error', { error });
-
-      if (this.isAPIError(error)) {
-        throw error;
-      }
-
-      const apiError: APIError = {
-        code: 'UNKNOWN_ERROR',
-        message: 'Failed to fetch kline series from Longbridge',
-        details: { originalError: error }
-      };
-      throw apiError;
-    }
+  private hasCredentials(): boolean {
+    return Boolean(
+      process.env.LONGPORT_APP_KEY &&
+        process.env.LONGPORT_APP_SECRET &&
+        process.env.LONGPORT_ACCESS_TOKEN
+    );
   }
 
   private normalizeSymbol(symbol: string): string {
@@ -200,10 +393,20 @@ export class LongbridgeProvider implements StockDataProvider {
   }
 
   private isAPIError(error: any): error is APIError {
+    const apiErrorCodes = [
+      'INVALID_SYMBOL',
+      'INVALID_INTERVAL',
+      'INVALID_PROVIDER',
+      'API_LIMIT_EXCEEDED',
+      'NETWORK_ERROR',
+      'INVALID_API_KEY',
+      'UNKNOWN_ERROR'
+    ];
+
     return (
       error &&
       typeof error === 'object' &&
-      'code' in error &&
+      apiErrorCodes.includes(error.code) &&
       'message' in error
     );
   }

--- a/src/lib/providers/types.ts
+++ b/src/lib/providers/types.ts
@@ -1,11 +1,28 @@
 import {
+  type APIErrorCode,
   type KLineInterval,
   KLineSeries,
   StockQuote
 } from '../types/stock-api';
 
+export type ProviderHealthStatus = 'healthy' | 'degraded' | 'unconfigured';
+
+export interface ProviderHealthCheck {
+  provider: string;
+  status: ProviderHealthStatus;
+  latencyMs: number;
+  checkedAt: string;
+  details?: {
+    code?: APIErrorCode;
+    message?: string;
+    retryAfter?: number;
+    [key: string]: unknown;
+  };
+}
+
 export interface StockDataProvider {
   name: string;
   getQuote(symbol: string): Promise<StockQuote>;
   getKLines(symbol: string, interval?: KLineInterval): Promise<KLineSeries>;
+  healthCheck(): Promise<ProviderHealthCheck>;
 }

--- a/src/lib/services/api-errors.ts
+++ b/src/lib/services/api-errors.ts
@@ -1,6 +1,16 @@
 import { NextResponse } from 'next/server';
 import { APIResponse, APIError, APIErrorCode } from '../types/stock-api';
 
+const API_ERROR_CODES = new Set<string>([
+  'INVALID_SYMBOL',
+  'INVALID_INTERVAL',
+  'INVALID_PROVIDER',
+  'API_LIMIT_EXCEEDED',
+  'NETWORK_ERROR',
+  'INVALID_API_KEY',
+  'UNKNOWN_ERROR'
+]);
+
 /**
  * Create a standardized error response
  */
@@ -16,8 +26,12 @@ export function createErrorResponse<T = null>(
   };
 
   const status = statusCode || getStatusCodeForError(error.code);
+  const retryAfter = getRetryAfterFromError(error);
+  const headers: HeadersInit = retryAfter
+    ? { 'Retry-After': String(retryAfter) }
+    : {};
 
-  return NextResponse.json(response, { status });
+  return NextResponse.json(response, { status, headers });
 }
 
 /**
@@ -82,6 +96,7 @@ export function isAPIError(error: unknown): error is APIError {
     'code' in error &&
     'message' in error &&
     typeof (error as Record<string, unknown>).code === 'string' &&
+    API_ERROR_CODES.has((error as Record<string, unknown>).code as string) &&
     typeof (error as Record<string, unknown>).message === 'string'
   );
 }
@@ -122,8 +137,7 @@ export function createRateLimitResponse(
   retryAfter?: number
 ): NextResponse<APIResponse<null>> {
   // Validate and cap retry time to reasonable limits (max 5 minutes)
-  const validRetryAfter =
-    retryAfter && retryAfter > 0 && retryAfter <= 300 ? retryAfter : undefined;
+  const validRetryAfter = getValidRetryAfter(retryAfter);
   const error = createAPIError(
     'API_LIMIT_EXCEEDED',
     'Rate limit exceeded. Please try again later.',
@@ -146,6 +160,29 @@ export function createRateLimitResponse(
       headers
     }
   );
+}
+
+export function getRetryAfterFromError(error: APIError): number | undefined {
+  return getValidRetryAfter(error.details?.retryAfter);
+}
+
+function getValidRetryAfter(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return value <= 300 ? Math.ceil(value) : undefined;
+  }
+
+  if (typeof value === 'string') {
+    const numericValue = Number(value);
+    if (
+      Number.isFinite(numericValue) &&
+      numericValue > 0 &&
+      numericValue <= 300
+    ) {
+      return Math.ceil(numericValue);
+    }
+  }
+
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add Longbridge provider health checks with a cached health probe and a new `/api/stocks/providers/health` route.
- Add server-side request guarding, retry/backoff, and error normalization for Longbridge quote and K-line calls.
- Update quote and K-line routes to use shared API error helpers and propagate `Retry-After` on 429s.

## Testing
- Added provider tests for quote/K-line behavior, retries, health states, and request-guard limits.
- Added route tests for health responses and `Retry-After` propagation.
- Verified the touched provider/service/API code with TypeScript, ESLint, Prettier, and targeted Jest suites.