### PR TITLE
Add technical indicator overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ alerts, reports, settings, and overview pages remain planned.
 - `/dashboard/stocks` with market overview, quote provider selection, ticker
   search, watchlist card, and portfolio holdings card.
 - `/dashboard/charts` with a klinecharts-based chart workspace for a selected
-  ticker, interval, range, and display preferences.
+  ticker, interval, range, display preferences, and configurable SMA, EMA, RSI,
+  MACD, Bollinger Bands, and VWAP indicators.
 - `/dashboard/operations` with setup diagnostics for Clerk, Supabase, and
   Longbridge configuration.
 - Longbridge-backed quote and k-line API routes.
@@ -35,8 +36,8 @@ alerts, reports, settings, and overview pages remain planned.
   history, lots, realized P&L, and tax workflows are not implemented.
 - Watchlist management exists inside the stock dashboard card, but does not yet
   have a dedicated full-page workflow.
-- Charting supports k-line visualization and display preferences, but does not
-  include a full indicator library.
+- Charting supports k-line visualization, display preferences, and the initial
+  technical indicator library. Custom indicator authoring is still planned.
 - Dashboard UX still carries some starter-shell structure while the app becomes
   fully stock-tracker-specific.
 
@@ -47,7 +48,7 @@ alerts, reports, settings, and overview pages remain planned.
 - Reports, exports, and tax-oriented workflows.
 - Settings page for user preferences and alert configuration.
 - Full dashboard overview page instead of redirecting `/dashboard` to stocks.
-- Advanced technical indicators and analytics.
+- Custom technical indicators and analytics.
 - Committed screenshots for the README.
 
 ## Feature Matrix

--- a/src/features/stock-dashboard/components/ChartPageClient.tsx
+++ b/src/features/stock-dashboard/components/ChartPageClient.tsx
@@ -16,7 +16,7 @@ import {
 import {
   buildChartsHref,
   isChartRange,
-  type ChartPreferences,
+  type ChartPreferencesPatch,
   type ChartRange
 } from '../lib/chart-workspace';
 
@@ -41,9 +41,7 @@ export function ChartPageClient() {
     return rawSymbol ? rawSymbol.toUpperCase() : null;
   }, [searchParams]);
   const rawInterval = searchParams.get('interval')?.toLowerCase();
-  const queryInterval = isKLineInterval(rawInterval)
-    ? rawInterval
-    : null;
+  const queryInterval = isKLineInterval(rawInterval) ? rawInterval : null;
   const rawRange = searchParams.get('range')?.toLowerCase();
   const queryRange = isChartRange(rawRange) ? rawRange : null;
 
@@ -127,46 +125,35 @@ export function ChartPageClient() {
 
   const handleTickerSubmit = (ticker: string) => {
     router.replace(
-      buildChartsHref(
-        new URLSearchParams(searchParams.toString()),
-        {
-          symbol: ticker,
-          interval,
-          range
-        }
-      )
+      buildChartsHref(new URLSearchParams(searchParams.toString()), {
+        symbol: ticker,
+        interval,
+        range
+      })
     );
   };
 
   const handleIntervalChange = (nextInterval: KLineInterval) => {
     router.replace(
-      buildChartsHref(
-        new URLSearchParams(searchParams.toString()),
-        {
-          symbol: activeTicker,
-          interval: nextInterval,
-          range
-        }
-      )
+      buildChartsHref(new URLSearchParams(searchParams.toString()), {
+        symbol: activeTicker,
+        interval: nextInterval,
+        range
+      })
     );
   };
 
   const handleRangeChange = (nextRange: ChartRange) => {
     router.replace(
-      buildChartsHref(
-        new URLSearchParams(searchParams.toString()),
-        {
-          symbol: activeTicker,
-          interval,
-          range: nextRange
-        }
-      )
+      buildChartsHref(new URLSearchParams(searchParams.toString()), {
+        symbol: activeTicker,
+        interval,
+        range: nextRange
+      })
     );
   };
 
-  const handlePreferencesChange = (
-    preferences: Partial<ChartPreferences>
-  ) => {
+  const handlePreferencesChange = (preferences: ChartPreferencesPatch) => {
     setChartPreferences(preferences);
   };
 

--- a/src/features/stock-dashboard/components/KLineChart.tsx
+++ b/src/features/stock-dashboard/components/KLineChart.tsx
@@ -8,6 +8,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { Input } from '@/components/ui/input';
 import Link from 'next/link';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
@@ -28,10 +29,19 @@ import {
   filterCandlesByRange,
   isChartCandleType,
   isChartRange,
+  normalizeChartPreferences,
   type ChartCandleType,
   type ChartPreferences,
+  type ChartPreferencesPatch,
   type ChartRange
 } from '../lib/chart-workspace';
+import {
+  TECHNICAL_INDICATOR_IDS,
+  normalizeIntegerParameter,
+  normalizeNumberParameter,
+  type TechnicalIndicatorId,
+  type TechnicalIndicatorPreferencePatch
+} from '../lib/technical-indicators';
 
 interface KLineChartProps {
   ticker: string;
@@ -42,7 +52,7 @@ interface KLineChartProps {
   range?: ChartRange;
   onRangeChange?: (range: ChartRange) => void;
   preferences?: ChartPreferences;
-  onPreferencesChange?: (preferences: Partial<ChartPreferences>) => void;
+  onPreferencesChange?: (preferences: ChartPreferencesPatch) => void;
 }
 
 const KLINE_INTERVAL_META: Record<
@@ -86,6 +96,58 @@ const CANDLE_TYPE_OPTIONS: Array<{
   { label: 'OHLC', value: 'ohlc' },
   { label: 'Area', value: 'area' }
 ];
+
+const INDICATOR_OPTIONS: Array<{
+  label: string;
+  value: TechnicalIndicatorId;
+}> = [
+  { label: 'SMA', value: 'sma' },
+  { label: 'EMA', value: 'ema' },
+  { label: 'RSI', value: 'rsi' },
+  { label: 'MACD', value: 'macd' },
+  { label: 'BB', value: 'bollinger' },
+  { label: 'VWAP', value: 'vwap' }
+];
+
+interface IndicatorNumberInputProps {
+  id: string;
+  label: string;
+  value: number;
+  min?: number;
+  max?: number;
+  step?: number;
+  onValueChange: (value: string) => void;
+}
+
+function IndicatorNumberInput({
+  id,
+  label,
+  value,
+  min = 1,
+  max = 500,
+  step = 1,
+  onValueChange
+}: IndicatorNumberInputProps) {
+  return (
+    <div className='flex items-center gap-1'>
+      <Label htmlFor={id} className='sr-only'>
+        {label}
+      </Label>
+      <Input
+        id={id}
+        aria-label={label}
+        type='number'
+        inputMode='decimal'
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        className='h-8 w-20 px-2 text-xs'
+        onChange={(event) => onValueChange(event.target.value)}
+      />
+    </div>
+  );
+}
 
 function getIntervalMeta(interval: KLineInterval) {
   return KLINE_INTERVAL_META[interval];
@@ -145,18 +207,35 @@ export function KLineChart({
   const [chartError, setChartError] = useState<string | null>(null);
   const [retryTrigger, setRetryTrigger] = useState(0);
   const intervalRef = useRef(interval);
-  const preferencesRef = useRef(preferences);
+  const normalizedPreferences = useMemo(
+    () => normalizeChartPreferences(preferences),
+    [preferences]
+  );
+  const preferencesRef = useRef(normalizedPreferences);
 
   intervalRef.current = interval;
-  preferencesRef.current = preferences;
+  preferencesRef.current = normalizedPreferences;
 
   const activePreferences = useMemo(
     () => ({
-      showVolume: preferences.showVolume,
-      showGrid: preferences.showGrid,
-      candleType: preferences.candleType
+      showVolume: normalizedPreferences.showVolume,
+      showGrid: normalizedPreferences.showGrid,
+      candleType: normalizedPreferences.candleType,
+      indicators: normalizedPreferences.indicators
     }),
-    [preferences.candleType, preferences.showGrid, preferences.showVolume]
+    [
+      normalizedPreferences.candleType,
+      normalizedPreferences.indicators,
+      normalizedPreferences.showGrid,
+      normalizedPreferences.showVolume
+    ]
+  );
+  const enabledIndicatorIds = useMemo(
+    () =>
+      TECHNICAL_INDICATOR_IDS.filter(
+        (indicatorId) => normalizedPreferences.indicators[indicatorId].enabled
+      ),
+    [normalizedPreferences.indicators]
   );
 
   const filteredCandles = useMemo(
@@ -245,7 +324,12 @@ export function KLineChart({
 
   useEffect(() => {
     if (!chartRef.current || !querySymbol) return;
-    chartRef.current.update(querySymbol, chartData, interval, activePreferences);
+    chartRef.current.update(
+      querySymbol,
+      chartData,
+      interval,
+      activePreferences
+    );
   }, [activePreferences, chartData, chartReady, interval, querySymbol]);
 
   const handleRetry = () => {
@@ -253,6 +337,32 @@ export function KLineChart({
       setRetryTrigger((prev) => prev + 1);
     }
     refetch();
+  };
+
+  const updateIndicatorPreference = (
+    indicator: TechnicalIndicatorId,
+    patch: NonNullable<TechnicalIndicatorPreferencePatch[TechnicalIndicatorId]>
+  ) => {
+    onPreferencesChange?.({
+      indicators: {
+        [indicator]: patch
+      }
+    });
+  };
+
+  const handleIndicatorToggleChange = (values: string[]) => {
+    const enabledIndicators = new Set(values);
+    const indicators = TECHNICAL_INDICATOR_IDS.reduce(
+      (patch, indicator) => ({
+        ...patch,
+        [indicator]: {
+          enabled: enabledIndicators.has(indicator)
+        }
+      }),
+      {} as TechnicalIndicatorPreferencePatch
+    );
+
+    onPreferencesChange?.({ indicators });
   };
 
   const busy = isLoading || !chartReady;
@@ -368,7 +478,7 @@ export function KLineChart({
               <div className='flex items-center gap-2'>
                 <Switch
                   id='chart-volume'
-                  checked={preferences.showVolume}
+                  checked={normalizedPreferences.showVolume}
                   onCheckedChange={(showVolume) =>
                     onPreferencesChange?.({ showVolume })
                   }
@@ -380,7 +490,7 @@ export function KLineChart({
               <div className='flex items-center gap-2'>
                 <Switch
                   id='chart-grid'
-                  checked={preferences.showGrid}
+                  checked={normalizedPreferences.showGrid}
                   onCheckedChange={(showGrid) =>
                     onPreferencesChange?.({ showGrid })
                   }
@@ -391,7 +501,7 @@ export function KLineChart({
               </div>
               <ToggleGroup
                 type='single'
-                value={preferences.candleType}
+                value={normalizedPreferences.candleType}
                 variant='outline'
                 size='sm'
                 aria-label='Candle type'
@@ -399,7 +509,7 @@ export function KLineChart({
                 onValueChange={(value) => {
                   if (
                     isChartCandleType(value) &&
-                    value !== preferences.candleType
+                    value !== normalizedPreferences.candleType
                   ) {
                     onPreferencesChange?.({ candleType: value });
                   }
@@ -415,6 +525,211 @@ export function KLineChart({
                   </ToggleGroupItem>
                 ))}
               </ToggleGroup>
+            </div>
+            <div className='border-border/70 flex w-full flex-col gap-2 border-t pt-3 lg:max-w-3xl'>
+              <div className='flex flex-wrap items-center justify-start gap-2 lg:justify-end'>
+                <span className='text-muted-foreground text-xs font-medium'>
+                  Indicators
+                </span>
+                <ToggleGroup
+                  type='multiple'
+                  value={enabledIndicatorIds}
+                  variant='outline'
+                  size='sm'
+                  aria-label='Technical indicators'
+                  className='w-full flex-wrap sm:w-auto'
+                  onValueChange={handleIndicatorToggleChange}
+                >
+                  {INDICATOR_OPTIONS.map((option) => (
+                    <ToggleGroupItem
+                      key={option.value}
+                      value={option.value}
+                      aria-label={`${option.label} indicator`}
+                    >
+                      {option.label}
+                    </ToggleGroupItem>
+                  ))}
+                </ToggleGroup>
+              </div>
+              {enabledIndicatorIds.length > 0 && (
+                <div className='grid gap-2 sm:grid-cols-2 xl:grid-cols-3'>
+                  {normalizedPreferences.indicators.sma.enabled && (
+                    <div className='flex items-center gap-2'>
+                      <span className='text-muted-foreground w-12 text-xs font-medium'>
+                        SMA
+                      </span>
+                      <IndicatorNumberInput
+                        id='chart-sma-period'
+                        label='SMA period'
+                        value={normalizedPreferences.indicators.sma.period}
+                        onValueChange={(value) =>
+                          updateIndicatorPreference('sma', {
+                            period: normalizeIntegerParameter(
+                              value,
+                              normalizedPreferences.indicators.sma.period
+                            )
+                          })
+                        }
+                      />
+                    </div>
+                  )}
+                  {normalizedPreferences.indicators.ema.enabled && (
+                    <div className='flex items-center gap-2'>
+                      <span className='text-muted-foreground w-12 text-xs font-medium'>
+                        EMA
+                      </span>
+                      <IndicatorNumberInput
+                        id='chart-ema-period'
+                        label='EMA period'
+                        value={normalizedPreferences.indicators.ema.period}
+                        onValueChange={(value) =>
+                          updateIndicatorPreference('ema', {
+                            period: normalizeIntegerParameter(
+                              value,
+                              normalizedPreferences.indicators.ema.period
+                            )
+                          })
+                        }
+                      />
+                    </div>
+                  )}
+                  {normalizedPreferences.indicators.rsi.enabled && (
+                    <div className='flex items-center gap-2'>
+                      <span className='text-muted-foreground w-12 text-xs font-medium'>
+                        RSI
+                      </span>
+                      <IndicatorNumberInput
+                        id='chart-rsi-period'
+                        label='RSI period'
+                        value={normalizedPreferences.indicators.rsi.period}
+                        onValueChange={(value) =>
+                          updateIndicatorPreference('rsi', {
+                            period: normalizeIntegerParameter(
+                              value,
+                              normalizedPreferences.indicators.rsi.period
+                            )
+                          })
+                        }
+                      />
+                    </div>
+                  )}
+                  {normalizedPreferences.indicators.vwap.enabled && (
+                    <div className='flex items-center gap-2'>
+                      <span className='text-muted-foreground w-12 text-xs font-medium'>
+                        VWAP
+                      </span>
+                      <IndicatorNumberInput
+                        id='chart-vwap-period'
+                        label='VWAP period'
+                        value={normalizedPreferences.indicators.vwap.period}
+                        onValueChange={(value) =>
+                          updateIndicatorPreference('vwap', {
+                            period: normalizeIntegerParameter(
+                              value,
+                              normalizedPreferences.indicators.vwap.period
+                            )
+                          })
+                        }
+                      />
+                    </div>
+                  )}
+                  {normalizedPreferences.indicators.bollinger.enabled && (
+                    <div className='flex items-center gap-2'>
+                      <span className='text-muted-foreground w-12 text-xs font-medium'>
+                        BB
+                      </span>
+                      <IndicatorNumberInput
+                        id='chart-bollinger-period'
+                        label='Bollinger Bands period'
+                        value={
+                          normalizedPreferences.indicators.bollinger.period
+                        }
+                        onValueChange={(value) =>
+                          updateIndicatorPreference('bollinger', {
+                            period: normalizeIntegerParameter(
+                              value,
+                              normalizedPreferences.indicators.bollinger.period
+                            )
+                          })
+                        }
+                      />
+                      <IndicatorNumberInput
+                        id='chart-bollinger-standard-deviations'
+                        label='Bollinger Bands standard deviations'
+                        value={
+                          normalizedPreferences.indicators.bollinger
+                            .standardDeviations
+                        }
+                        min={0.1}
+                        max={10}
+                        step={0.1}
+                        onValueChange={(value) =>
+                          updateIndicatorPreference('bollinger', {
+                            standardDeviations: normalizeNumberParameter(
+                              value,
+                              normalizedPreferences.indicators.bollinger
+                                .standardDeviations,
+                              {
+                                min: 0.1,
+                                max: 10,
+                                precision: 2
+                              }
+                            )
+                          })
+                        }
+                      />
+                    </div>
+                  )}
+                  {normalizedPreferences.indicators.macd.enabled && (
+                    <div className='flex items-center gap-2 sm:col-span-2 xl:col-span-3'>
+                      <span className='text-muted-foreground w-12 text-xs font-medium'>
+                        MACD
+                      </span>
+                      <IndicatorNumberInput
+                        id='chart-macd-fast-period'
+                        label='MACD fast period'
+                        value={normalizedPreferences.indicators.macd.fastPeriod}
+                        onValueChange={(value) =>
+                          updateIndicatorPreference('macd', {
+                            fastPeriod: normalizeIntegerParameter(
+                              value,
+                              normalizedPreferences.indicators.macd.fastPeriod
+                            )
+                          })
+                        }
+                      />
+                      <IndicatorNumberInput
+                        id='chart-macd-slow-period'
+                        label='MACD slow period'
+                        value={normalizedPreferences.indicators.macd.slowPeriod}
+                        onValueChange={(value) =>
+                          updateIndicatorPreference('macd', {
+                            slowPeriod: normalizeIntegerParameter(
+                              value,
+                              normalizedPreferences.indicators.macd.slowPeriod
+                            )
+                          })
+                        }
+                      />
+                      <IndicatorNumberInput
+                        id='chart-macd-signal-period'
+                        label='MACD signal period'
+                        value={
+                          normalizedPreferences.indicators.macd.signalPeriod
+                        }
+                        onValueChange={(value) =>
+                          updateIndicatorPreference('macd', {
+                            signalPeriod: normalizeIntegerParameter(
+                              value,
+                              normalizedPreferences.indicators.macd.signalPeriod
+                            )
+                          })
+                        }
+                      />
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/src/features/stock-dashboard/components/__tests__/KLineChart.test.tsx
+++ b/src/features/stock-dashboard/components/__tests__/KLineChart.test.tsx
@@ -2,13 +2,14 @@
  * @jest-environment jsdom
  */
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { KLineChart } from '../KLineChart';
 import { useKlineSeries } from '../../hooks/useKlineSeries';
 import { StockApiResponseError } from '../../lib/stock-api-error';
 import { createKLineChart } from '../../lib/klinecharts';
 import type { KLineCandle, KLineInterval } from '@/lib/types/stock-api';
+import { normalizeChartPreferences } from '../../lib/chart-workspace';
 
 jest.mock('../../hooks/useKlineSeries');
 jest.mock('../../lib/klinecharts', () => ({
@@ -228,9 +229,9 @@ describe('KLineChart', () => {
     const latestCall = calls[calls.length - 1];
 
     expect(latestCall[1]).toHaveLength(2);
-    expect(latestCall[1].map((candle: { close: number }) => candle.close)).toEqual([
-      108, 114
-    ]);
+    expect(
+      latestCall[1].map((candle: { close: number }) => candle.close)
+    ).toEqual([108, 114]);
   });
 
   it('passes display preferences to the klinecharts adapter', async () => {
@@ -257,7 +258,76 @@ describe('KLineChart', () => {
       symbol: 'AAPL',
       interval: 'day',
       data: [],
-      preferences
+      preferences: normalizeChartPreferences(preferences)
+    });
+  });
+
+  it('renders indicator controls and persists parameter changes', async () => {
+    mockUseKlineSeries.mockReturnValue({
+      data: buildSeries('day'),
+      isLoading: false,
+      isError: false,
+      error: null,
+      noData: false,
+      refetch: jest.fn()
+    } as any);
+
+    const onPreferencesChange = jest.fn();
+    const preferences = normalizeChartPreferences({
+      indicators: {
+        sma: {
+          enabled: true,
+          period: 20
+        },
+        macd: {
+          enabled: true,
+          fastPeriod: 12,
+          slowPeriod: 26,
+          signalPeriod: 9
+        }
+      }
+    });
+
+    render(
+      <KLineChart
+        ticker='AAPL'
+        preferences={preferences}
+        onPreferencesChange={onPreferencesChange}
+      />
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'SMA indicator' })
+    ).toHaveAttribute('data-state', 'on');
+    expect(screen.getByLabelText('SMA period')).toHaveValue(20);
+    expect(screen.getByLabelText('MACD fast period')).toHaveValue(12);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'EMA indicator' })
+    );
+
+    expect(onPreferencesChange).toHaveBeenCalledWith({
+      indicators: expect.objectContaining({
+        ema: {
+          enabled: true
+        }
+      })
+    });
+
+    onPreferencesChange.mockClear();
+
+    fireEvent.change(screen.getByLabelText('SMA period'), {
+      target: {
+        value: '30'
+      }
+    });
+
+    expect(onPreferencesChange).toHaveBeenLastCalledWith({
+      indicators: {
+        sma: {
+          period: 30
+        }
+      }
     });
   });
 

--- a/src/features/stock-dashboard/components/__tests__/chart-page-client.test.tsx
+++ b/src/features/stock-dashboard/components/__tests__/chart-page-client.test.tsx
@@ -9,6 +9,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import {
   DEFAULT_CHART_WORKSPACE,
   type ChartPreferences,
+  type ChartPreferencesPatch,
   type ChartRange
 } from '../../lib/chart-workspace';
 import type { KLineInterval } from '@/lib/types/stock-api';
@@ -41,7 +42,7 @@ jest.mock('../KLineChart', () => ({
     preferences: ChartPreferences;
     onIntervalChange?: (interval: KLineInterval) => void;
     onRangeChange?: (range: ChartRange) => void;
-    onPreferencesChange?: (preferences: Partial<ChartPreferences>) => void;
+    onPreferencesChange?: (preferences: ChartPreferencesPatch) => void;
   }) => (
     <div>
       <div data-testid='kline-chart'>{`${ticker}:${interval}:${range}`}</div>
@@ -138,15 +139,17 @@ describe('ChartPageClient', () => {
         range: '6m'
       })
     );
-    (useDashboardStore as unknown as jest.Mock).mockReturnValue(createStore({
-      selectedTicker: 'GOOGL',
-      chartWorkspace: {
-        ...DEFAULT_CHART_WORKSPACE,
-        symbol: 'AAPL',
-        interval: 'day',
-        range: '1m'
-      }
-    }));
+    (useDashboardStore as unknown as jest.Mock).mockReturnValue(
+      createStore({
+        selectedTicker: 'GOOGL',
+        chartWorkspace: {
+          ...DEFAULT_CHART_WORKSPACE,
+          symbol: 'AAPL',
+          interval: 'day',
+          range: '1m'
+        }
+      })
+    );
 
     render(<ChartPageClient />);
 
@@ -160,13 +163,15 @@ describe('ChartPageClient', () => {
     (useSearchParams as jest.Mock).mockReturnValue(
       createSearchParams({ symbol: 'AAPL' })
     );
-    (useDashboardStore as unknown as jest.Mock).mockReturnValue(createStore({
-      selectedTicker: 'AAPL',
-      chartWorkspace: {
-        ...DEFAULT_CHART_WORKSPACE,
-        symbol: 'AAPL'
-      }
-    }));
+    (useDashboardStore as unknown as jest.Mock).mockReturnValue(
+      createStore({
+        selectedTicker: 'AAPL',
+        chartWorkspace: {
+          ...DEFAULT_CHART_WORKSPACE,
+          symbol: 'AAPL'
+        }
+      })
+    );
 
     render(<ChartPageClient />);
 
@@ -178,14 +183,16 @@ describe('ChartPageClient', () => {
 
     (useRouter as jest.Mock).mockReturnValue({ replace });
     (useSearchParams as jest.Mock).mockReturnValue(createSearchParams({}));
-    (useDashboardStore as unknown as jest.Mock).mockReturnValue(createStore({
-      chartWorkspace: {
-        ...DEFAULT_CHART_WORKSPACE,
-        symbol: 'NVDA',
-        interval: 'month',
-        range: '3m'
-      }
-    }));
+    (useDashboardStore as unknown as jest.Mock).mockReturnValue(
+      createStore({
+        chartWorkspace: {
+          ...DEFAULT_CHART_WORKSPACE,
+          symbol: 'NVDA',
+          interval: 'month',
+          range: '3m'
+        }
+      })
+    );
 
     render(<ChartPageClient />);
 
@@ -205,15 +212,17 @@ describe('ChartPageClient', () => {
         range: '3m'
       })
     );
-    (useDashboardStore as unknown as jest.Mock).mockReturnValue(createStore({
-      selectedTicker: 'MSFT',
-      chartWorkspace: {
-        ...DEFAULT_CHART_WORKSPACE,
-        symbol: 'MSFT',
-        interval: 'week',
-        range: '3m'
-      }
-    }));
+    (useDashboardStore as unknown as jest.Mock).mockReturnValue(
+      createStore({
+        selectedTicker: 'MSFT',
+        chartWorkspace: {
+          ...DEFAULT_CHART_WORKSPACE,
+          symbol: 'MSFT',
+          interval: 'week',
+          range: '3m'
+        }
+      })
+    );
 
     render(<ChartPageClient />);
     fireEvent.click(screen.getByRole('button', { name: 'Switch Interval' }));
@@ -252,15 +261,17 @@ describe('ChartPageClient', () => {
         range: '3m'
       })
     );
-    (useDashboardStore as unknown as jest.Mock).mockReturnValue(createStore({
-      selectedTicker: 'MSFT',
-      chartWorkspace: {
-        ...DEFAULT_CHART_WORKSPACE,
-        symbol: 'MSFT',
-        interval: 'week',
-        range: '3m'
-      }
-    }));
+    (useDashboardStore as unknown as jest.Mock).mockReturnValue(
+      createStore({
+        selectedTicker: 'MSFT',
+        chartWorkspace: {
+          ...DEFAULT_CHART_WORKSPACE,
+          symbol: 'MSFT',
+          interval: 'week',
+          range: '3m'
+        }
+      })
+    );
 
     render(<ChartPageClient />);
     fireEvent.click(screen.getByRole('button', { name: 'Switch Range' }));
@@ -282,16 +293,18 @@ describe('ChartPageClient', () => {
         range: '3m'
       })
     );
-    (useDashboardStore as unknown as jest.Mock).mockReturnValue(createStore({
-      selectedTicker: 'MSFT',
-      setChartPreferences,
-      chartWorkspace: {
-        ...DEFAULT_CHART_WORKSPACE,
-        symbol: 'MSFT',
-        interval: 'week',
-        range: '3m'
-      }
-    }));
+    (useDashboardStore as unknown as jest.Mock).mockReturnValue(
+      createStore({
+        selectedTicker: 'MSFT',
+        setChartPreferences,
+        chartWorkspace: {
+          ...DEFAULT_CHART_WORKSPACE,
+          symbol: 'MSFT',
+          interval: 'week',
+          range: '3m'
+        }
+      })
+    );
 
     render(<ChartPageClient />);
     fireEvent.click(screen.getByRole('button', { name: 'Toggle Grid' }));

--- a/src/features/stock-dashboard/lib/chart-workspace.ts
+++ b/src/features/stock-dashboard/lib/chart-workspace.ts
@@ -4,24 +4,34 @@ import {
   type KLineCandle,
   type KLineInterval
 } from '@/lib/types/stock-api';
+import {
+  DEFAULT_TECHNICAL_INDICATORS,
+  mergeTechnicalIndicatorPreferences,
+  normalizeTechnicalIndicators,
+  type TechnicalIndicatorPreferencePatch,
+  type TechnicalIndicatorPreferences
+} from './technical-indicators';
 
 export const CHART_WORKSPACE_STORAGE_KEY = 'dashboard:chartWorkspace:v1';
 
 export const CHART_RANGES = ['1m', '3m', '6m', '1y', 'max'] as const;
 export type ChartRange = (typeof CHART_RANGES)[number];
 
-export const CHART_CANDLE_TYPES = [
-  'candle_solid',
-  'ohlc',
-  'area'
-] as const;
+export const CHART_CANDLE_TYPES = ['candle_solid', 'ohlc', 'area'] as const;
 export type ChartCandleType = (typeof CHART_CANDLE_TYPES)[number];
 
 export interface ChartPreferences {
   showVolume: boolean;
   showGrid: boolean;
   candleType: ChartCandleType;
+  indicators: TechnicalIndicatorPreferences;
 }
+
+export type ChartPreferencesPatch = Partial<
+  Omit<ChartPreferences, 'indicators'>
+> & {
+  indicators?: TechnicalIndicatorPreferencePatch;
+};
 
 export interface ChartWorkspace {
   symbol: string | null;
@@ -41,7 +51,8 @@ export const DEFAULT_CHART_WORKSPACE: ChartWorkspace = {
   preferences: {
     showVolume: true,
     showGrid: true,
-    candleType: 'candle_solid'
+    candleType: 'candle_solid',
+    indicators: DEFAULT_TECHNICAL_INDICATORS
   }
 };
 
@@ -55,6 +66,44 @@ export function isChartCandleType(
   value: string | null | undefined
 ): value is ChartCandleType {
   return CHART_CANDLE_TYPES.includes(value as ChartCandleType);
+}
+
+export function normalizeChartPreferences(
+  preferences:
+    | (Partial<Omit<ChartPreferences, 'indicators'>> & {
+        indicators?: unknown;
+      })
+    | null
+    | undefined
+): ChartPreferences {
+  return {
+    showVolume:
+      typeof preferences?.showVolume === 'boolean'
+        ? preferences.showVolume
+        : DEFAULT_CHART_WORKSPACE.preferences.showVolume,
+    showGrid:
+      typeof preferences?.showGrid === 'boolean'
+        ? preferences.showGrid
+        : DEFAULT_CHART_WORKSPACE.preferences.showGrid,
+    candleType: isChartCandleType(preferences?.candleType)
+      ? preferences.candleType
+      : DEFAULT_CHART_WORKSPACE.preferences.candleType,
+    indicators: normalizeTechnicalIndicators(preferences?.indicators)
+  };
+}
+
+export function mergeChartPreferences(
+  current: ChartPreferences,
+  patch: ChartPreferencesPatch
+): ChartPreferences {
+  return normalizeChartPreferences({
+    ...current,
+    ...patch,
+    indicators: mergeTechnicalIndicatorPreferences(
+      current.indicators,
+      patch.indicators
+    )
+  });
 }
 
 export function parseChartWorkspace(raw: string | null): ChartWorkspace {
@@ -82,19 +131,7 @@ export function parseChartWorkspace(raw: string | null): ChartWorkspace {
       range: isChartRange(parsed.range)
         ? parsed.range
         : DEFAULT_CHART_WORKSPACE.range,
-      preferences: {
-        showVolume:
-          typeof preferences?.showVolume === 'boolean'
-            ? preferences.showVolume
-            : DEFAULT_CHART_WORKSPACE.preferences.showVolume,
-        showGrid:
-          typeof preferences?.showGrid === 'boolean'
-            ? preferences.showGrid
-            : DEFAULT_CHART_WORKSPACE.preferences.showGrid,
-        candleType: isChartCandleType(preferences?.candleType)
-          ? preferences.candleType
-          : DEFAULT_CHART_WORKSPACE.preferences.candleType
-      }
+      preferences: normalizeChartPreferences(preferences)
     };
   } catch {
     return DEFAULT_CHART_WORKSPACE;
@@ -122,7 +159,9 @@ export function filterCandlesByRange(
     startDate.setMonth(startDate.getMonth() - months);
   }
 
-  const filtered = candles.filter((candle) => candle.timestamp >= startDate.getTime());
+  const filtered = candles.filter(
+    (candle) => candle.timestamp >= startDate.getTime()
+  );
 
   return filtered.length > 0 ? filtered : [candles[candles.length - 1]];
 }

--- a/src/features/stock-dashboard/lib/klinecharts.ts
+++ b/src/features/stock-dashboard/lib/klinecharts.ts
@@ -1,9 +1,19 @@
-import type { Chart, KLineData } from 'klinecharts';
+import type { Chart, IndicatorTemplate, KLineData } from 'klinecharts';
 import type { KLineInterval } from '@/lib/types/stock-api';
 import {
   DEFAULT_CHART_WORKSPACE,
   type ChartPreferences
 } from './chart-workspace';
+import {
+  calculateBollingerBands,
+  calculateEMA,
+  calculateMACD,
+  calculateRSI,
+  calculateSMA,
+  calculateVWAP,
+  normalizeTechnicalIndicators,
+  type TechnicalIndicatorPreferences
+} from './technical-indicators';
 
 export interface KLineChartHandle {
   update: (
@@ -23,10 +33,226 @@ export interface CreateKLineChartOptions {
 }
 
 let klineModule: typeof import('klinecharts') | null = null;
+let technicalIndicatorsRegistered = false;
+
+const CANDLE_PANE_ID = 'candle_pane';
+const VOLUME_PANE_ID = 'volume-pane';
+
+const TECHNICAL_INDICATOR_NAMES = {
+  sma: 'STOCK_TRACKER_SMA',
+  ema: 'STOCK_TRACKER_EMA',
+  rsi: 'STOCK_TRACKER_RSI',
+  macd: 'STOCK_TRACKER_MACD',
+  bollinger: 'STOCK_TRACKER_BOLLINGER',
+  vwap: 'STOCK_TRACKER_VWAP'
+} as const;
+
+const TECHNICAL_INDICATOR_PANES = {
+  rsi: 'rsi-pane',
+  macd: 'macd-pane'
+} as const;
+
+type IndicatorResult = Record<string, number>;
+
+function mapSingleValueResult(
+  values: Array<number | null>,
+  key: string
+): IndicatorResult[] {
+  return values.map((value) => (value === null ? {} : { [key]: value }));
+}
+
+function createLineStyles(colors: string[]) {
+  return {
+    lines: colors.map((color) => ({
+      style: 'solid' as const,
+      smooth: false,
+      size: 1,
+      dashedValue: [2, 2],
+      color
+    }))
+  };
+}
+
+function registerTechnicalIndicatorTemplates(
+  registerIndicator: (typeof import('klinecharts'))['registerIndicator']
+) {
+  if (technicalIndicatorsRegistered) {
+    return;
+  }
+
+  const smaIndicator: IndicatorTemplate<IndicatorResult, number> = {
+    name: TECHNICAL_INDICATOR_NAMES.sma,
+    shortName: 'SMA',
+    series: 'price',
+    calcParams: [DEFAULT_CHART_WORKSPACE.preferences.indicators.sma.period],
+    precision: 2,
+    shouldOhlc: true,
+    figures: [{ key: 'sma', title: 'SMA: ', type: 'line' }],
+    styles: createLineStyles(['#2563eb']),
+    regenerateFigures: ([period]) => [
+      { key: 'sma', title: `SMA${period}: `, type: 'line' }
+    ],
+    calc: (dataList, indicator) =>
+      mapSingleValueResult(
+        calculateSMA(dataList, indicator.calcParams[0]),
+        'sma'
+      )
+  };
+
+  const emaIndicator: IndicatorTemplate<IndicatorResult, number> = {
+    name: TECHNICAL_INDICATOR_NAMES.ema,
+    shortName: 'EMA',
+    series: 'price',
+    calcParams: [DEFAULT_CHART_WORKSPACE.preferences.indicators.ema.period],
+    precision: 2,
+    shouldOhlc: true,
+    figures: [{ key: 'ema', title: 'EMA: ', type: 'line' }],
+    styles: createLineStyles(['#ea580c']),
+    regenerateFigures: ([period]) => [
+      { key: 'ema', title: `EMA${period}: `, type: 'line' }
+    ],
+    calc: (dataList, indicator) =>
+      mapSingleValueResult(
+        calculateEMA(dataList, indicator.calcParams[0]),
+        'ema'
+      )
+  };
+
+  const rsiIndicator: IndicatorTemplate<IndicatorResult, number> = {
+    name: TECHNICAL_INDICATOR_NAMES.rsi,
+    shortName: 'RSI',
+    calcParams: [DEFAULT_CHART_WORKSPACE.preferences.indicators.rsi.period],
+    precision: 2,
+    minValue: 0,
+    maxValue: 100,
+    figures: [{ key: 'rsi', title: 'RSI: ', type: 'line' }],
+    styles: createLineStyles(['#7c3aed']),
+    regenerateFigures: ([period]) => [
+      { key: 'rsi', title: `RSI${period}: `, type: 'line' }
+    ],
+    calc: (dataList, indicator) =>
+      mapSingleValueResult(
+        calculateRSI(dataList, indicator.calcParams[0]),
+        'rsi'
+      )
+  };
+
+  const macdIndicator: IndicatorTemplate<IndicatorResult, number> = {
+    name: TECHNICAL_INDICATOR_NAMES.macd,
+    shortName: 'MACD',
+    calcParams: [
+      DEFAULT_CHART_WORKSPACE.preferences.indicators.macd.fastPeriod,
+      DEFAULT_CHART_WORKSPACE.preferences.indicators.macd.slowPeriod,
+      DEFAULT_CHART_WORKSPACE.preferences.indicators.macd.signalPeriod
+    ],
+    precision: 4,
+    figures: [
+      { key: 'macd', title: 'MACD: ', type: 'line' },
+      { key: 'signal', title: 'Signal: ', type: 'line' },
+      {
+        key: 'histogram',
+        title: 'Hist: ',
+        type: 'bar',
+        baseValue: 0,
+        styles: ({ data }) => {
+          const histogram = data.current?.histogram ?? 0;
+          const color = histogram >= 0 ? '#16a34a' : '#dc2626';
+
+          return {
+            style: 'fill',
+            color,
+            borderColor: color
+          };
+        }
+      }
+    ],
+    styles: createLineStyles(['#0f766e', '#be123c']),
+    calc: (dataList, indicator) =>
+      calculateMACD(
+        dataList,
+        indicator.calcParams[0],
+        indicator.calcParams[1],
+        indicator.calcParams[2]
+      ).map((point) => ({
+        ...(point.macd === null ? {} : { macd: point.macd }),
+        ...(point.signal === null ? {} : { signal: point.signal }),
+        ...(point.histogram === null ? {} : { histogram: point.histogram })
+      }))
+  };
+
+  const bollingerIndicator: IndicatorTemplate<IndicatorResult, number> = {
+    name: TECHNICAL_INDICATOR_NAMES.bollinger,
+    shortName: 'BB',
+    series: 'price',
+    calcParams: [
+      DEFAULT_CHART_WORKSPACE.preferences.indicators.bollinger.period,
+      DEFAULT_CHART_WORKSPACE.preferences.indicators.bollinger
+        .standardDeviations
+    ],
+    precision: 2,
+    shouldOhlc: true,
+    figures: [
+      { key: 'upper', title: 'Upper: ', type: 'line' },
+      { key: 'middle', title: 'Middle: ', type: 'line' },
+      { key: 'lower', title: 'Lower: ', type: 'line' }
+    ],
+    styles: createLineStyles(['#0891b2', '#64748b', '#0891b2']),
+    regenerateFigures: ([period, standardDeviations]) => [
+      {
+        key: 'upper',
+        title: `BB${period}/${standardDeviations} Upper: `,
+        type: 'line'
+      },
+      { key: 'middle', title: 'Middle: ', type: 'line' },
+      { key: 'lower', title: 'Lower: ', type: 'line' }
+    ],
+    calc: (dataList, indicator) =>
+      calculateBollingerBands(
+        dataList,
+        indicator.calcParams[0],
+        indicator.calcParams[1]
+      ).map((point) => ({
+        ...(point.upper === null ? {} : { upper: point.upper }),
+        ...(point.middle === null ? {} : { middle: point.middle }),
+        ...(point.lower === null ? {} : { lower: point.lower })
+      }))
+  };
+
+  const vwapIndicator: IndicatorTemplate<IndicatorResult, number> = {
+    name: TECHNICAL_INDICATOR_NAMES.vwap,
+    shortName: 'VWAP',
+    series: 'price',
+    calcParams: [DEFAULT_CHART_WORKSPACE.preferences.indicators.vwap.period],
+    precision: 2,
+    shouldOhlc: true,
+    figures: [{ key: 'vwap', title: 'VWAP: ', type: 'line' }],
+    styles: createLineStyles(['#ca8a04']),
+    regenerateFigures: ([period]) => [
+      { key: 'vwap', title: `VWAP${period}: `, type: 'line' }
+    ],
+    calc: (dataList, indicator) =>
+      mapSingleValueResult(
+        calculateVWAP(dataList, indicator.calcParams[0]),
+        'vwap'
+      )
+  };
+
+  [
+    smaIndicator,
+    emaIndicator,
+    rsiIndicator,
+    macdIndicator,
+    bollingerIndicator,
+    vwapIndicator
+  ].forEach((indicator) => registerIndicator(indicator));
+
+  technicalIndicatorsRegistered = true;
+}
 
 async function getKLineModule() {
   if (!klineModule) {
     klineModule = await import('klinecharts');
+    registerTechnicalIndicatorTemplates(klineModule.registerIndicator);
   }
   return klineModule;
 }
@@ -52,6 +278,10 @@ function applyData(
 }
 
 function applyPreferences(chart: Chart, preferences: ChartPreferences) {
+  const technicalIndicators = normalizeTechnicalIndicators(
+    preferences.indicators
+  );
+
   chart.setStyles({
     grid: {
       show: preferences.showGrid,
@@ -71,7 +301,7 @@ function applyPreferences(chart: Chart, preferences: ChartPreferences) {
 
   if (preferences.showVolume && volumeIndicators.length === 0) {
     chart.createIndicator('VOL', false, {
-      id: 'volume-pane',
+      id: VOLUME_PANE_ID,
       height: 120,
       minHeight: 80
     });
@@ -80,6 +310,108 @@ function applyPreferences(chart: Chart, preferences: ChartPreferences) {
   if (!preferences.showVolume && volumeIndicators.length > 0) {
     chart.removeIndicator({ name: 'VOL' });
   }
+
+  applyTechnicalIndicators(chart, technicalIndicators);
+}
+
+function syncTechnicalIndicator(
+  chart: Chart,
+  options: {
+    enabled: boolean;
+    id: string;
+    name: string;
+    calcParams: number[];
+    paneId: string;
+    height?: number;
+  }
+) {
+  const existingIndicators = chart.getIndicators({ id: options.id });
+
+  if (!options.enabled) {
+    if (existingIndicators.length > 0) {
+      chart.removeIndicator({ id: options.id });
+    }
+    return;
+  }
+
+  const indicator = {
+    id: options.id,
+    name: options.name,
+    calcParams: options.calcParams
+  };
+
+  if (existingIndicators.length === 0) {
+    chart.createIndicator(indicator, true, {
+      id: options.paneId,
+      height: options.height,
+      minHeight: options.height ? 90 : undefined
+    });
+    return;
+  }
+
+  chart.overrideIndicator(indicator);
+}
+
+function applyTechnicalIndicators(
+  chart: Chart,
+  indicators: TechnicalIndicatorPreferences
+) {
+  syncTechnicalIndicator(chart, {
+    enabled: indicators.sma.enabled,
+    id: TECHNICAL_INDICATOR_NAMES.sma,
+    name: TECHNICAL_INDICATOR_NAMES.sma,
+    calcParams: [indicators.sma.period],
+    paneId: CANDLE_PANE_ID
+  });
+
+  syncTechnicalIndicator(chart, {
+    enabled: indicators.ema.enabled,
+    id: TECHNICAL_INDICATOR_NAMES.ema,
+    name: TECHNICAL_INDICATOR_NAMES.ema,
+    calcParams: [indicators.ema.period],
+    paneId: CANDLE_PANE_ID
+  });
+
+  syncTechnicalIndicator(chart, {
+    enabled: indicators.bollinger.enabled,
+    id: TECHNICAL_INDICATOR_NAMES.bollinger,
+    name: TECHNICAL_INDICATOR_NAMES.bollinger,
+    calcParams: [
+      indicators.bollinger.period,
+      indicators.bollinger.standardDeviations
+    ],
+    paneId: CANDLE_PANE_ID
+  });
+
+  syncTechnicalIndicator(chart, {
+    enabled: indicators.vwap.enabled,
+    id: TECHNICAL_INDICATOR_NAMES.vwap,
+    name: TECHNICAL_INDICATOR_NAMES.vwap,
+    calcParams: [indicators.vwap.period],
+    paneId: CANDLE_PANE_ID
+  });
+
+  syncTechnicalIndicator(chart, {
+    enabled: indicators.rsi.enabled,
+    id: TECHNICAL_INDICATOR_NAMES.rsi,
+    name: TECHNICAL_INDICATOR_NAMES.rsi,
+    calcParams: [indicators.rsi.period],
+    paneId: TECHNICAL_INDICATOR_PANES.rsi,
+    height: 120
+  });
+
+  syncTechnicalIndicator(chart, {
+    enabled: indicators.macd.enabled,
+    id: TECHNICAL_INDICATOR_NAMES.macd,
+    name: TECHNICAL_INDICATOR_NAMES.macd,
+    calcParams: [
+      indicators.macd.fastPeriod,
+      indicators.macd.slowPeriod,
+      indicators.macd.signalPeriod
+    ],
+    paneId: TECHNICAL_INDICATOR_PANES.macd,
+    height: 140
+  });
 }
 
 function updateChart(
@@ -124,14 +456,7 @@ export async function createKLineChart(
       data,
       interval,
       preferences = options.preferences ?? DEFAULT_CHART_WORKSPACE.preferences
-    ) =>
-      updateChart(
-        chart,
-        symbol,
-        data,
-        interval,
-        preferences
-      ),
+    ) => updateChart(chart, symbol, data, interval, preferences),
     destroy: () => {
       resizeObserver.disconnect();
       dispose(chart);

--- a/src/features/stock-dashboard/lib/technical-indicators.test.ts
+++ b/src/features/stock-dashboard/lib/technical-indicators.test.ts
@@ -1,0 +1,126 @@
+import {
+  calculateBollingerBands,
+  calculateEMA,
+  calculateMACD,
+  calculateRSI,
+  calculateSMA,
+  calculateVWAP,
+  normalizeTechnicalIndicators,
+  type IndicatorCandle
+} from './technical-indicators';
+
+function buildCandles(closes: number[]): IndicatorCandle[] {
+  return closes.map((close) => ({
+    high: close,
+    low: close,
+    close,
+    volume: 100
+  }));
+}
+
+describe('technical indicators', () => {
+  it('calculates simple moving averages with null warm-up values', () => {
+    expect(calculateSMA(buildCandles([1, 2, 3, 4, 5]), 3)).toEqual([
+      null,
+      null,
+      2,
+      3,
+      4
+    ]);
+  });
+
+  it('calculates exponential moving averages seeded from the first window', () => {
+    expect(calculateEMA(buildCandles([1, 2, 3, 4, 5]), 3)).toEqual([
+      null,
+      null,
+      2,
+      3,
+      4
+    ]);
+  });
+
+  it('calculates Wilder RSI values from close-to-close gains and losses', () => {
+    expect(calculateRSI(buildCandles([1, 2, 3, 2, 1]), 2)).toEqual([
+      null,
+      null,
+      100,
+      50,
+      25
+    ]);
+  });
+
+  it('calculates MACD line, signal line, and histogram', () => {
+    const macd = calculateMACD(buildCandles([1, 2, 4, 8, 16]), 2, 3, 2);
+
+    expect(macd[0]).toEqual({
+      macd: null,
+      signal: null,
+      histogram: null
+    });
+    expect(macd[2].macd).toBeCloseTo(0.8333, 4);
+    expect(macd[3].signal).toBeCloseTo(1.0278, 4);
+    expect(macd[4].histogram).toBeCloseTo(0.3951, 4);
+  });
+
+  it('calculates Bollinger Bands from the rolling close variance', () => {
+    const bands = calculateBollingerBands(buildCandles([1, 2, 3]), 3, 2);
+
+    expect(bands[0]).toEqual({
+      middle: null,
+      upper: null,
+      lower: null
+    });
+    expect(bands[2].middle).toBeCloseTo(2);
+    expect(bands[2].upper).toBeCloseTo(3.633, 3);
+    expect(bands[2].lower).toBeCloseTo(0.367, 3);
+  });
+
+  it('calculates rolling volume weighted average price', () => {
+    const vwap = calculateVWAP(
+      [
+        { high: 2, low: 0, close: 1, volume: 10 },
+        { high: 3, low: 1, close: 2, volume: 30 },
+        { high: 6, low: 3, close: 3, volume: 20 }
+      ],
+      2
+    );
+
+    expect(vwap[0]).toBeNull();
+    expect(vwap[1]).toBeCloseTo(1.75);
+    expect(vwap[2]).toBeCloseTo(2.8);
+  });
+
+  it('normalizes indicator preferences and clamps invalid parameters', () => {
+    expect(
+      normalizeTechnicalIndicators({
+        sma: { enabled: true, period: '30' },
+        ema: { enabled: 'yes', period: -5 },
+        macd: {
+          enabled: true,
+          fastPeriod: 20,
+          slowPeriod: 10,
+          signalPeriod: 'x'
+        },
+        bollinger: {
+          enabled: true,
+          period: 20,
+          standardDeviations: 50
+        }
+      })
+    ).toMatchObject({
+      sma: { enabled: true, period: 30 },
+      ema: { enabled: false, period: 1 },
+      macd: {
+        enabled: true,
+        fastPeriod: 9,
+        slowPeriod: 10,
+        signalPeriod: 9
+      },
+      bollinger: {
+        enabled: true,
+        period: 20,
+        standardDeviations: 10
+      }
+    });
+  });
+});

--- a/src/features/stock-dashboard/lib/technical-indicators.ts
+++ b/src/features/stock-dashboard/lib/technical-indicators.ts
@@ -1,0 +1,544 @@
+export interface IndicatorCandle {
+  high: number;
+  low: number;
+  close: number;
+  volume?: number | null;
+}
+
+export type NullableIndicatorValue = number | null;
+
+export interface BollingerBandsPoint {
+  middle: NullableIndicatorValue;
+  upper: NullableIndicatorValue;
+  lower: NullableIndicatorValue;
+}
+
+export interface MacdPoint {
+  macd: NullableIndicatorValue;
+  signal: NullableIndicatorValue;
+  histogram: NullableIndicatorValue;
+}
+
+export interface IntegerParameterOptions {
+  min?: number;
+  max?: number;
+}
+
+export interface NumberParameterOptions extends IntegerParameterOptions {
+  precision?: number;
+}
+
+export const TECHNICAL_INDICATOR_IDS = [
+  'sma',
+  'ema',
+  'rsi',
+  'macd',
+  'bollinger',
+  'vwap'
+] as const;
+
+export type TechnicalIndicatorId = (typeof TECHNICAL_INDICATOR_IDS)[number];
+
+export interface PeriodIndicatorPreference {
+  enabled: boolean;
+  period: number;
+}
+
+export interface MacdIndicatorPreference {
+  enabled: boolean;
+  fastPeriod: number;
+  slowPeriod: number;
+  signalPeriod: number;
+}
+
+export interface BollingerBandsIndicatorPreference
+  extends PeriodIndicatorPreference {
+  standardDeviations: number;
+}
+
+export interface TechnicalIndicatorPreferences {
+  sma: PeriodIndicatorPreference;
+  ema: PeriodIndicatorPreference;
+  rsi: PeriodIndicatorPreference;
+  macd: MacdIndicatorPreference;
+  bollinger: BollingerBandsIndicatorPreference;
+  vwap: PeriodIndicatorPreference;
+}
+
+export type TechnicalIndicatorPreferencePatch = {
+  [K in keyof TechnicalIndicatorPreferences]?: Partial<
+    TechnicalIndicatorPreferences[K]
+  >;
+};
+
+export const DEFAULT_TECHNICAL_INDICATORS: TechnicalIndicatorPreferences = {
+  sma: {
+    enabled: false,
+    period: 20
+  },
+  ema: {
+    enabled: false,
+    period: 20
+  },
+  rsi: {
+    enabled: false,
+    period: 14
+  },
+  macd: {
+    enabled: false,
+    fastPeriod: 12,
+    slowPeriod: 26,
+    signalPeriod: 9
+  },
+  bollinger: {
+    enabled: false,
+    period: 20,
+    standardDeviations: 2
+  },
+  vwap: {
+    enabled: false,
+    period: 20
+  }
+};
+
+const DEFAULT_PERIOD_LIMITS = {
+  min: 1,
+  max: 500
+};
+
+export function normalizeIntegerParameter(
+  value: unknown,
+  fallback: number,
+  options: IntegerParameterOptions = {}
+) {
+  const min = options.min ?? DEFAULT_PERIOD_LIMITS.min;
+  const max = options.max ?? DEFAULT_PERIOD_LIMITS.max;
+  const numericValue =
+    typeof value === 'number' ? value : Number.parseFloat(String(value));
+
+  if (!Number.isFinite(numericValue)) {
+    return fallback;
+  }
+
+  return Math.min(max, Math.max(min, Math.round(numericValue)));
+}
+
+export function normalizeNumberParameter(
+  value: unknown,
+  fallback: number,
+  options: NumberParameterOptions = {}
+) {
+  const min = options.min ?? 0;
+  const max = options.max ?? 100;
+  const precision = options.precision ?? 2;
+  const numericValue =
+    typeof value === 'number' ? value : Number.parseFloat(String(value));
+
+  if (!Number.isFinite(numericValue)) {
+    return fallback;
+  }
+
+  const clampedValue = Math.min(max, Math.max(min, numericValue));
+  const multiplier = 10 ** precision;
+
+  return Math.round(clampedValue * multiplier) / multiplier;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function normalizeEnabled(
+  value: Record<string, unknown> | undefined,
+  fallback: boolean
+) {
+  return typeof value?.enabled === 'boolean' ? value.enabled : fallback;
+}
+
+function normalizePeriodPreference(
+  value: unknown,
+  fallback: PeriodIndicatorPreference
+): PeriodIndicatorPreference {
+  const rawPreference = isRecord(value) ? value : undefined;
+
+  return {
+    enabled: normalizeEnabled(rawPreference, fallback.enabled),
+    period: normalizeIntegerParameter(rawPreference?.period, fallback.period)
+  };
+}
+
+function normalizeMacdPreference(
+  value: unknown,
+  fallback: MacdIndicatorPreference
+): MacdIndicatorPreference {
+  const rawPreference = isRecord(value) ? value : undefined;
+  const fastPeriod = normalizeIntegerParameter(
+    rawPreference?.fastPeriod,
+    fallback.fastPeriod
+  );
+  const slowPeriod = normalizeIntegerParameter(
+    rawPreference?.slowPeriod,
+    fallback.slowPeriod
+  );
+  const normalizedFastPeriod = Math.max(
+    1,
+    Math.min(fastPeriod, slowPeriod - 1)
+  );
+  const normalizedSlowPeriod = Math.max(slowPeriod, normalizedFastPeriod + 1);
+
+  return {
+    enabled: normalizeEnabled(rawPreference, fallback.enabled),
+    fastPeriod: normalizedFastPeriod,
+    slowPeriod: normalizedSlowPeriod,
+    signalPeriod: normalizeIntegerParameter(
+      rawPreference?.signalPeriod,
+      fallback.signalPeriod
+    )
+  };
+}
+
+function normalizeBollingerPreference(
+  value: unknown,
+  fallback: BollingerBandsIndicatorPreference
+): BollingerBandsIndicatorPreference {
+  const rawPreference = isRecord(value) ? value : undefined;
+  const periodPreference = normalizePeriodPreference(value, fallback);
+
+  return {
+    ...periodPreference,
+    standardDeviations: normalizeNumberParameter(
+      rawPreference?.standardDeviations,
+      fallback.standardDeviations,
+      {
+        min: 0.1,
+        max: 10,
+        precision: 2
+      }
+    )
+  };
+}
+
+export function normalizeTechnicalIndicators(
+  value: unknown
+): TechnicalIndicatorPreferences {
+  const rawIndicators = isRecord(value) ? value : {};
+
+  return {
+    sma: normalizePeriodPreference(
+      rawIndicators.sma,
+      DEFAULT_TECHNICAL_INDICATORS.sma
+    ),
+    ema: normalizePeriodPreference(
+      rawIndicators.ema,
+      DEFAULT_TECHNICAL_INDICATORS.ema
+    ),
+    rsi: normalizePeriodPreference(
+      rawIndicators.rsi,
+      DEFAULT_TECHNICAL_INDICATORS.rsi
+    ),
+    macd: normalizeMacdPreference(
+      rawIndicators.macd,
+      DEFAULT_TECHNICAL_INDICATORS.macd
+    ),
+    bollinger: normalizeBollingerPreference(
+      rawIndicators.bollinger,
+      DEFAULT_TECHNICAL_INDICATORS.bollinger
+    ),
+    vwap: normalizePeriodPreference(
+      rawIndicators.vwap,
+      DEFAULT_TECHNICAL_INDICATORS.vwap
+    )
+  };
+}
+
+export function mergeTechnicalIndicatorPreferences(
+  current: TechnicalIndicatorPreferences,
+  patch: TechnicalIndicatorPreferencePatch | undefined
+) {
+  if (!patch) {
+    return normalizeTechnicalIndicators(current);
+  }
+
+  return normalizeTechnicalIndicators({
+    sma: {
+      ...current.sma,
+      ...patch.sma
+    },
+    ema: {
+      ...current.ema,
+      ...patch.ema
+    },
+    rsi: {
+      ...current.rsi,
+      ...patch.rsi
+    },
+    macd: {
+      ...current.macd,
+      ...patch.macd
+    },
+    bollinger: {
+      ...current.bollinger,
+      ...patch.bollinger
+    },
+    vwap: {
+      ...current.vwap,
+      ...patch.vwap
+    }
+  });
+}
+
+function getClose(candle: IndicatorCandle) {
+  return Number.isFinite(candle.close) ? candle.close : 0;
+}
+
+function getTypicalPrice(candle: IndicatorCandle) {
+  const high = Number.isFinite(candle.high) ? candle.high : getClose(candle);
+  const low = Number.isFinite(candle.low) ? candle.low : getClose(candle);
+
+  return (high + low + getClose(candle)) / 3;
+}
+
+function calculateRsiValue(averageGain: number, averageLoss: number) {
+  if (averageGain === 0 && averageLoss === 0) {
+    return 50;
+  }
+
+  if (averageLoss === 0) {
+    return 100;
+  }
+
+  if (averageGain === 0) {
+    return 0;
+  }
+
+  const relativeStrength = averageGain / averageLoss;
+
+  return 100 - 100 / (1 + relativeStrength);
+}
+
+function calculateNullableEma(
+  values: NullableIndicatorValue[],
+  period: number
+) {
+  const normalizedPeriod = normalizeIntegerParameter(period, 1);
+  const result: NullableIndicatorValue[] = Array(values.length).fill(null);
+  const multiplier = 2 / (normalizedPeriod + 1);
+  let seedSum = 0;
+  let seedCount = 0;
+  let previousEma: NullableIndicatorValue = null;
+
+  values.forEach((value, index) => {
+    if (value === null) {
+      return;
+    }
+
+    if (previousEma === null) {
+      seedSum += value;
+      seedCount += 1;
+
+      if (seedCount === normalizedPeriod) {
+        previousEma = seedSum / normalizedPeriod;
+        result[index] = previousEma;
+      }
+
+      return;
+    }
+
+    previousEma = value * multiplier + previousEma * (1 - multiplier);
+    result[index] = previousEma;
+  });
+
+  return result;
+}
+
+export function calculateSMA(
+  candles: IndicatorCandle[],
+  period: number
+): NullableIndicatorValue[] {
+  const normalizedPeriod = normalizeIntegerParameter(period, 1);
+  const result: NullableIndicatorValue[] = Array(candles.length).fill(null);
+  let rollingSum = 0;
+
+  candles.forEach((candle, index) => {
+    rollingSum += getClose(candle);
+
+    if (index >= normalizedPeriod) {
+      rollingSum -= getClose(candles[index - normalizedPeriod]);
+    }
+
+    if (index >= normalizedPeriod - 1) {
+      result[index] = rollingSum / normalizedPeriod;
+    }
+  });
+
+  return result;
+}
+
+export function calculateEMA(
+  candles: IndicatorCandle[],
+  period: number
+): NullableIndicatorValue[] {
+  const normalizedPeriod = normalizeIntegerParameter(period, 1);
+  const closes = candles.map((candle) => getClose(candle));
+
+  return calculateNullableEma(closes, normalizedPeriod);
+}
+
+export function calculateRSI(
+  candles: IndicatorCandle[],
+  period: number
+): NullableIndicatorValue[] {
+  const normalizedPeriod = normalizeIntegerParameter(period, 1);
+  const result: NullableIndicatorValue[] = Array(candles.length).fill(null);
+  let averageGain = 0;
+  let averageLoss = 0;
+
+  for (let index = 1; index < candles.length; index += 1) {
+    const change = getClose(candles[index]) - getClose(candles[index - 1]);
+    const gain = Math.max(change, 0);
+    const loss = Math.max(-change, 0);
+
+    if (index <= normalizedPeriod) {
+      averageGain += gain;
+      averageLoss += loss;
+
+      if (index === normalizedPeriod) {
+        averageGain /= normalizedPeriod;
+        averageLoss /= normalizedPeriod;
+        result[index] = calculateRsiValue(averageGain, averageLoss);
+      }
+
+      continue;
+    }
+
+    averageGain =
+      (averageGain * (normalizedPeriod - 1) + gain) / normalizedPeriod;
+    averageLoss =
+      (averageLoss * (normalizedPeriod - 1) + loss) / normalizedPeriod;
+    result[index] = calculateRsiValue(averageGain, averageLoss);
+  }
+
+  return result;
+}
+
+export function calculateMACD(
+  candles: IndicatorCandle[],
+  fastPeriod: number,
+  slowPeriod: number,
+  signalPeriod: number
+): MacdPoint[] {
+  const normalizedFastPeriod = normalizeIntegerParameter(fastPeriod, 12);
+  const normalizedSlowPeriod = Math.max(
+    normalizeIntegerParameter(slowPeriod, 26),
+    normalizedFastPeriod + 1
+  );
+  const normalizedSignalPeriod = normalizeIntegerParameter(signalPeriod, 9);
+  const fastEma = calculateEMA(candles, normalizedFastPeriod);
+  const slowEma = calculateEMA(candles, normalizedSlowPeriod);
+  const macd = fastEma.map((fastValue, index) => {
+    const slowValue = slowEma[index];
+
+    if (fastValue === null || slowValue === null) {
+      return null;
+    }
+
+    return fastValue - slowValue;
+  });
+  const signal = calculateNullableEma(macd, normalizedSignalPeriod);
+
+  return macd.map((macdValue, index) => {
+    const signalValue = signal[index];
+
+    return {
+      macd: macdValue,
+      signal: signalValue,
+      histogram:
+        macdValue === null || signalValue === null
+          ? null
+          : macdValue - signalValue
+    };
+  });
+}
+
+export function calculateBollingerBands(
+  candles: IndicatorCandle[],
+  period: number,
+  standardDeviations: number
+): BollingerBandsPoint[] {
+  const normalizedPeriod = normalizeIntegerParameter(period, 20);
+  const normalizedStandardDeviations = normalizeNumberParameter(
+    standardDeviations,
+    2,
+    {
+      min: 0.1,
+      max: 10,
+      precision: 2
+    }
+  );
+  let rollingSum = 0;
+  let rollingSquaredSum = 0;
+
+  return candles.map((candle, index) => {
+    const close = getClose(candle);
+    rollingSum += close;
+    rollingSquaredSum += close * close;
+
+    if (index >= normalizedPeriod) {
+      const removedClose = getClose(candles[index - normalizedPeriod]);
+      rollingSum -= removedClose;
+      rollingSquaredSum -= removedClose * removedClose;
+    }
+
+    if (index < normalizedPeriod - 1) {
+      return {
+        middle: null,
+        upper: null,
+        lower: null
+      };
+    }
+
+    const middle = rollingSum / normalizedPeriod;
+    const variance = Math.max(
+      rollingSquaredSum / normalizedPeriod - middle * middle,
+      0
+    );
+    const standardDeviation = Math.sqrt(variance);
+    const bandWidth = normalizedStandardDeviations * standardDeviation;
+
+    return {
+      middle,
+      upper: middle + bandWidth,
+      lower: middle - bandWidth
+    };
+  });
+}
+
+export function calculateVWAP(
+  candles: IndicatorCandle[],
+  period: number
+): NullableIndicatorValue[] {
+  const normalizedPeriod = normalizeIntegerParameter(period, 1);
+  const result: NullableIndicatorValue[] = Array(candles.length).fill(null);
+  let rollingPriceVolume = 0;
+  let rollingVolume = 0;
+
+  candles.forEach((candle, index) => {
+    const volume = Math.max(Number(candle.volume ?? 0), 0);
+    const priceVolume = getTypicalPrice(candle) * volume;
+    rollingPriceVolume += priceVolume;
+    rollingVolume += volume;
+
+    if (index >= normalizedPeriod) {
+      const removedCandle = candles[index - normalizedPeriod];
+      const removedVolume = Math.max(Number(removedCandle.volume ?? 0), 0);
+      rollingPriceVolume -= getTypicalPrice(removedCandle) * removedVolume;
+      rollingVolume -= removedVolume;
+    }
+
+    if (index >= normalizedPeriod - 1 && rollingVolume > 0) {
+      result[index] = rollingPriceVolume / rollingVolume;
+    }
+  });
+
+  return result;
+}

--- a/src/features/stock-dashboard/store.test.ts
+++ b/src/features/stock-dashboard/store.test.ts
@@ -94,7 +94,8 @@ describe('dashboard provider state', () => {
       preferences: {
         showVolume: false,
         showGrid: true,
-        candleType: 'area'
+        candleType: 'area',
+        indicators: DEFAULT_CHART_WORKSPACE.preferences.indicators
       }
     });
   });
@@ -152,14 +153,54 @@ describe('dashboard provider state', () => {
       });
     });
 
-    expect(JSON.parse(localStorage.getItem(CHART_WORKSPACE_STORAGE_KEY)!)).toEqual({
+    expect(
+      JSON.parse(localStorage.getItem(CHART_WORKSPACE_STORAGE_KEY)!)
+    ).toEqual({
       symbol: 'NVDA',
       interval: 'month',
       range: '6m',
       preferences: {
         showVolume: false,
         showGrid: true,
-        candleType: 'ohlc'
+        candleType: 'ohlc',
+        indicators: DEFAULT_CHART_WORKSPACE.preferences.indicators
+      }
+    });
+  });
+
+  it('persists nested chart indicator preferences without replacing siblings', () => {
+    act(() => {
+      useDashboardStore.getState().setChartPreferences({
+        indicators: {
+          sma: {
+            enabled: true,
+            period: 50
+          }
+        }
+      });
+      useDashboardStore.getState().setChartPreferences({
+        indicators: {
+          macd: {
+            enabled: true,
+            fastPeriod: 8
+          }
+        }
+      });
+    });
+
+    expect(
+      JSON.parse(localStorage.getItem(CHART_WORKSPACE_STORAGE_KEY)!).preferences
+        .indicators
+    ).toEqual({
+      ...DEFAULT_CHART_WORKSPACE.preferences.indicators,
+      sma: {
+        enabled: true,
+        period: 50
+      },
+      macd: {
+        ...DEFAULT_CHART_WORKSPACE.preferences.indicators.macd,
+        enabled: true,
+        fastPeriod: 8
       }
     });
   });

--- a/src/features/stock-dashboard/store.ts
+++ b/src/features/stock-dashboard/store.ts
@@ -8,8 +8,9 @@ import {
 import {
   CHART_WORKSPACE_STORAGE_KEY,
   DEFAULT_CHART_WORKSPACE,
+  mergeChartPreferences,
   parseChartWorkspace,
-  type ChartPreferences,
+  type ChartPreferencesPatch,
   type ChartWorkspace
 } from './lib/chart-workspace';
 
@@ -33,7 +34,7 @@ interface DashboardActions {
   addToLastTickers: (ticker: string) => void;
   setQuoteProvider: (provider: string) => void;
   setChartWorkspace: (workspace: Partial<ChartWorkspace>) => void;
-  setChartPreferences: (preferences: Partial<ChartPreferences>) => void;
+  setChartPreferences: (preferences: ChartPreferencesPatch) => void;
   hydrateFromStorage: () => void;
 }
 
@@ -110,24 +111,20 @@ export const useDashboardStore = create<DashboardState & DashboardActions>()(
       const nextWorkspace = {
         ...current,
         ...workspace,
-        preferences: {
-          ...current.preferences,
-          ...(workspace.preferences ?? {})
-        }
+        preferences: workspace.preferences
+          ? mergeChartPreferences(current.preferences, workspace.preferences)
+          : current.preferences
       };
 
       set({ chartWorkspace: nextWorkspace });
       persistChartWorkspace(nextWorkspace);
     },
 
-    setChartPreferences: (preferences: Partial<ChartPreferences>) => {
+    setChartPreferences: (preferences: ChartPreferencesPatch) => {
       const current = get().chartWorkspace;
       const nextWorkspace = {
         ...current,
-        preferences: {
-          ...current.preferences,
-          ...preferences
-        }
+        preferences: mergeChartPreferences(current.preferences, preferences)
       };
 
       set({ chartWorkspace: nextWorkspace });


### PR DESCRIPTION
## Summary
- Add reusable calculations for SMA, EMA, RSI, MACD, Bollinger Bands, and VWAP
- Register chart overlays and indicator panes in the KLineCharts adapter
- Extend persisted chart preferences and UI controls to enable indicators and edit parameters
- Update README status to reflect the implemented indicator library

## Testing
- Added unit coverage for indicator calculations and preference normalization
- Added component and store tests for indicator toggles, parameter edits, and persistence
- Validated the full Jest suite