### PR TITLE
Add multi-provider market data registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ alerts, reports, settings, and overview pages remain planned.
 - `/dashboard/charts` with a klinecharts-based chart workspace for a selected
   ticker, interval, range, and display preferences.
 - `/dashboard/operations` with setup diagnostics for Clerk, Supabase, and
-  Longbridge configuration.
-- Longbridge-backed quote and k-line API routes.
+  market data provider configuration.
+- Multi-provider quote and k-line API routes with Longbridge primary routing,
+  Yahoo Finance fallback, provider health metadata, and per-symbol provider
+  selection.
 - Watchlist API with Supabase persistence, symbol metadata, ordering, and tests.
 - Portfolio holdings API with Supabase persistence for current symbol quantity
   and average cost, plus tests.
@@ -83,16 +85,16 @@ alerts, reports, settings, and overview pages remain planned.
 
 ### API Routes
 
-| Route                          | Methods                          | Status      | Description                                                    |
-| :----------------------------- | :------------------------------- | :---------- | :------------------------------------------------------------- |
-| `/api/stocks/quote/[symbol]`   | `GET`                            | Implemented | Fetches a quote from the configured stock provider.            |
-| `/api/stocks/kline/[symbol]`   | `GET`                            | Implemented | Fetches k-line series data from the configured stock provider. |
-| `/api/stocks/providers/health` | `GET`                            | Implemented | Checks provider readiness.                                     |
-| `/api/ws/prices`               | `GET` WebSocket upgrade          | Implemented | Poll-backed price updates for subscribed symbols.              |
-| `/api/watchlist`               | `GET`, `POST`, `PATCH`, `DELETE` | Implemented | Authenticated watchlist CRUD, metadata, and ordering.          |
-| `/api/portfolio/holdings`      | `GET`, `POST`                    | Implemented | Authenticated current holdings list and creation.              |
-| `/api/portfolio/holdings/[id]` | `PATCH`, `DELETE`                | Implemented | Authenticated holdings update and deletion.                    |
-| `/api/log`                     | `POST`                           | Implemented | Client log ingestion.                                          |
+| Route                          | Methods                          | Status      | Description                                               |
+| :----------------------------- | :------------------------------- | :---------- | :-------------------------------------------------------- |
+| `/api/stocks/quote/[symbol]`   | `GET`                            | Implemented | Fetches a quote through the provider registry.            |
+| `/api/stocks/kline/[symbol]`   | `GET`                            | Implemented | Fetches k-line series data through the provider registry. |
+| `/api/stocks/providers/health` | `GET`                            | Implemented | Checks provider readiness and fallback metadata.          |
+| `/api/ws/prices`               | `GET` WebSocket upgrade          | Implemented | Poll-backed price updates for subscribed symbols.         |
+| `/api/watchlist`               | `GET`, `POST`, `PATCH`, `DELETE` | Implemented | Authenticated watchlist CRUD, metadata, and ordering.     |
+| `/api/portfolio/holdings`      | `GET`, `POST`                    | Implemented | Authenticated current holdings list and creation.         |
+| `/api/portfolio/holdings/[id]` | `PATCH`, `DELETE`                | Implemented | Authenticated holdings update and deletion.               |
+| `/api/log`                     | `POST`                           | Implemented | Client log ingestion.                                     |
 
 ## Tech Stack
 
@@ -102,7 +104,8 @@ alerts, reports, settings, and overview pages remain planned.
 - Styling: Tailwind CSS v4 and shadcn/ui components
 - Authentication: Clerk
 - Persistence: Supabase with Clerk-issued JWTs
-- Stock data provider: Longbridge
+- Stock data providers: Longbridge and Yahoo Finance fallback via the provider
+  registry
 - Charting: klinecharts
 - State management: Zustand and React Query
 - Validation: Zod and local ticker validation
@@ -183,8 +186,9 @@ cp env.example.txt .env.local
 4. Configure environment variables as needed:
 
 - Clerk: `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`
-- Longbridge: `LONGPORT_APP_KEY`, `LONGPORT_APP_SECRET`,
-  `LONGPORT_ACCESS_TOKEN`, `LONGPORT_REGION`
+- Longbridge primary provider: `LONGPORT_APP_KEY`, `LONGPORT_APP_SECRET`,
+  `LONGPORT_ACCESS_TOKEN`, `LONGPORT_REGION`. If these are missing, auto
+  routing can still fall back to the no-credential Yahoo Finance adapter.
 - Supabase: `NEXT_PUBLIC_SUPABASE_URL`,
   `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY`
 - Sentry: `NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_AUTH_TOKEN`,

--- a/env.example.txt
+++ b/env.example.txt
@@ -29,8 +29,12 @@ SENTRY_AUTH_TOKEN=    # 示例: sntrys_************************************
 NEXT_PUBLIC_SENTRY_DISABLED=false
 
 # =================================================================
-# Stock Data API Configuration (Longbridge)
+# Stock Data API Configuration
 # =================================================================
+# Default quote routing uses the built-in auto provider registry:
+# Longbridge is preferred for US/HK symbols, with Yahoo Finance as a
+# no-credential fallback adapter.
+#
 # Get API credentials from Longbridge User Center:
 # https://open.longbridgeapp.com/account
 #

--- a/src/app/api/stocks/providers/health/__tests__/route.test.ts
+++ b/src/app/api/stocks/providers/health/__tests__/route.test.ts
@@ -4,7 +4,10 @@
 import { GET } from '../route';
 import { StockProviderFactory } from '@/lib/providers/factory';
 import { APIResponse } from '@/lib/types/stock-api';
-import { ProviderHealthCheck } from '@/lib/providers/types';
+import {
+  ProviderHealthCheck,
+  ProviderHealthReport
+} from '@/lib/providers/types';
 import { createMockRequest } from '../../../__tests__/request-fixtures';
 
 jest.mock('next/server', () => ({
@@ -39,13 +42,18 @@ jest.mock('@sentry/nextjs', () => ({
 
 jest.mock('@/lib/providers/factory', () => ({
   StockProviderFactory: {
-    getProvider: jest.fn()
+    getProvider: jest.fn(),
+    getProviderHealthReport: jest.fn()
   }
 }));
 
 const mockGetProvider = StockProviderFactory.getProvider as jest.MockedFunction<
   typeof StockProviderFactory.getProvider
 >;
+const mockGetProviderHealthReport =
+  StockProviderFactory.getProviderHealthReport as jest.MockedFunction<
+    typeof StockProviderFactory.getProviderHealthReport
+  >;
 
 const mockProvider = {
   healthCheck: jest.fn()
@@ -57,9 +65,51 @@ describe('/api/stocks/providers/health API Route', () => {
     mockGetProvider.mockReturnValue(mockProvider as any);
   });
 
-  it('returns healthy provider status', async () => {
+  it('returns the auto provider health report by default', async () => {
+    const health: ProviderHealthReport = {
+      provider: 'Auto',
+      providerId: 'auto',
+      status: 'healthy',
+      checkedAt: '2024-01-01T00:00:00.000Z',
+      fallbackOrder: ['longbridge', 'yahoo'],
+      providers: [
+        {
+          provider: 'Longbridge',
+          providerId: 'longbridge',
+          status: 'healthy',
+          latencyMs: 12,
+          checkedAt: '2024-01-01T00:00:00.000Z'
+        },
+        {
+          provider: 'Yahoo Finance',
+          providerId: 'yahoo',
+          status: 'healthy',
+          latencyMs: 8,
+          checkedAt: '2024-01-01T00:00:00.000Z'
+        }
+      ],
+      metadata: []
+    };
+    mockGetProviderHealthReport.mockResolvedValue(health);
+
+    const response = await GET(
+      createMockRequest('http://localhost:3000/api/stocks/providers/health')
+    );
+    const responseData: APIResponse<ProviderHealthReport> =
+      await response.json();
+
+    expect(response.status).toBe(200);
+    expect(responseData.success).toBe(true);
+    expect(responseData.data).toEqual(health);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(mockGetProviderHealthReport).toHaveBeenCalledTimes(1);
+    expect(mockGetProvider).not.toHaveBeenCalled();
+  });
+
+  it('returns a concrete provider status when requested', async () => {
     const health: ProviderHealthCheck = {
       provider: 'Longbridge',
+      providerId: 'longbridge',
       status: 'healthy',
       latencyMs: 12,
       checkedAt: '2024-01-01T00:00:00.000Z',
@@ -70,15 +120,15 @@ describe('/api/stocks/providers/health API Route', () => {
     mockProvider.healthCheck.mockResolvedValue(health);
 
     const response = await GET(
-      createMockRequest('http://localhost:3000/api/stocks/providers/health')
+      createMockRequest(
+        'http://localhost:3000/api/stocks/providers/health?provider=longbridge'
+      )
     );
     const responseData: APIResponse<ProviderHealthCheck> =
       await response.json();
 
     expect(response.status).toBe(200);
-    expect(responseData.success).toBe(true);
     expect(responseData.data).toEqual(health);
-    expect(response.headers.get('Cache-Control')).toBe('no-store');
     expect(mockGetProvider).toHaveBeenCalledWith('longbridge');
   });
 
@@ -96,7 +146,9 @@ describe('/api/stocks/providers/health API Route', () => {
     mockProvider.healthCheck.mockResolvedValue(health);
 
     const response = await GET(
-      createMockRequest('http://localhost:3000/api/stocks/providers/health')
+      createMockRequest(
+        'http://localhost:3000/api/stocks/providers/health?provider=longbridge'
+      )
     );
     const responseData: APIResponse<ProviderHealthCheck> =
       await response.json();
@@ -121,7 +173,9 @@ describe('/api/stocks/providers/health API Route', () => {
     mockProvider.healthCheck.mockResolvedValue(health);
 
     const response = await GET(
-      createMockRequest('http://localhost:3000/api/stocks/providers/health')
+      createMockRequest(
+        'http://localhost:3000/api/stocks/providers/health?provider=longbridge'
+      )
     );
     const responseData: APIResponse<ProviderHealthCheck> =
       await response.json();

--- a/src/app/api/stocks/providers/health/route.ts
+++ b/src/app/api/stocks/providers/health/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest } from 'next/server';
 import * as Sentry from '@sentry/nextjs';
-import { CANONICAL_QUOTE_PROVIDER } from '@/lib/providers/config';
+import {
+  AUTO_QUOTE_PROVIDER,
+  CANONICAL_QUOTE_PROVIDER
+} from '@/lib/providers/config';
 import { StockProviderFactory } from '@/lib/providers/factory';
 import {
   createErrorResponse,
@@ -23,8 +26,12 @@ export async function GET(request: NextRequest) {
       span?.setAttribute('path', requestPath);
 
       try {
-        const provider = StockProviderFactory.getProvider(providerName);
-        const health = await provider.healthCheck();
+        const health =
+          providerName === AUTO_QUOTE_PROVIDER || providerName === 'all'
+            ? await StockProviderFactory.getProviderHealthReport()
+            : await StockProviderFactory.getProvider(
+                providerName
+              ).healthCheck();
 
         span?.setAttribute('provider.status', health.status);
 

--- a/src/features/operations/components/__tests__/setup-diagnostics-panel.test.tsx
+++ b/src/features/operations/components/__tests__/setup-diagnostics-panel.test.tsx
@@ -32,8 +32,8 @@ const diagnostics: SetupDiagnostics = {
         'Configure Supabase URL/key values and Clerk JWT template "supabase" for Clerk-issued Supabase tokens.'
     },
     {
-      id: 'longbridge',
-      title: 'Longbridge',
+      id: 'market-data',
+      title: 'Market data',
       status: 'warning',
       summary: 'Market data credentials need review.',
       details: ['Credential verification was skipped.'],
@@ -55,7 +55,7 @@ describe('SetupDiagnosticsPanel', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('Clerk')).toBeInTheDocument();
     expect(screen.getByText('Supabase')).toBeInTheDocument();
-    expect(screen.getByText('Longbridge')).toBeInTheDocument();
+    expect(screen.getByText('Market data')).toBeInTheDocument();
     expect(
       screen.getByText('Clerk JWT template "supabase" was not found.')
     ).toBeInTheDocument();

--- a/src/features/stock-dashboard/components/DashboardReadinessPanel.tsx
+++ b/src/features/stock-dashboard/components/DashboardReadinessPanel.tsx
@@ -20,7 +20,7 @@ import {
 } from '@tabler/icons-react';
 import Link from 'next/link';
 
-const READINESS_CHECK_IDS = new Set(['supabase', 'longbridge']);
+const READINESS_CHECK_IDS = new Set(['supabase', 'market-data']);
 
 const STATUS_CLASS_NAMES: Record<DiagnosticStatus, string> = {
   ready:

--- a/src/features/stock-dashboard/components/QuoteProviderToggle.tsx
+++ b/src/features/stock-dashboard/components/QuoteProviderToggle.tsx
@@ -2,26 +2,40 @@
 
 import { useDashboardStore } from '../store';
 import { QUOTE_PROVIDER_OPTIONS } from '@/lib/providers/config';
-import { Badge } from '@/components/ui/badge';
 import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select';
 
 export function QuoteProviderToggle() {
   const quoteProvider = useDashboardStore((state) => state.quoteProvider);
-  const providerLabel =
-    QUOTE_PROVIDER_OPTIONS.find((provider) => provider.value === quoteProvider)
-      ?.label ?? quoteProvider;
+  const setQuoteProvider = useDashboardStore((state) => state.setQuoteProvider);
 
   return (
     <div className='flex items-center space-x-2'>
       <Label className='text-muted-foreground text-sm font-medium'>
         Source:
       </Label>
-      <Badge
-        variant='outline'
-        className='h-8 min-w-[140px] justify-center rounded-md px-3 text-xs font-medium'
-      >
-        {providerLabel}
-      </Badge>
+      <Select value={quoteProvider} onValueChange={setQuoteProvider}>
+        <SelectTrigger
+          size='sm'
+          className='h-8 min-w-[160px] text-xs font-medium'
+          aria-label='Quote data source'
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {QUOTE_PROVIDER_OPTIONS.map((provider) => (
+            <SelectItem key={provider.value} value={provider.value}>
+              {provider.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
     </div>
   );
 }

--- a/src/features/stock-dashboard/components/WatchlistCard.tsx
+++ b/src/features/stock-dashboard/components/WatchlistCard.tsx
@@ -181,7 +181,9 @@ function createOptimisticItem(
 
 function toPricedItem(
   item: ApiWatchlistItem,
-  priceData: ReturnType<typeof useWatchlistPrices>['pricesMap'][string] | undefined
+  priceData:
+    | ReturnType<typeof useWatchlistPrices>['pricesMap'][string]
+    | undefined
 ): WatchlistItemWithPrice {
   return {
     id: item.id,
@@ -446,7 +448,9 @@ export function WatchlistCard() {
     if (!currentItem) return;
 
     const groupKey = getGroupKey(currentItem);
-    const groupItems = sortedItems.filter((item) => getGroupKey(item) === groupKey);
+    const groupItems = sortedItems.filter(
+      (item) => getGroupKey(item) === groupKey
+    );
     const currentIndex = groupItems.findIndex(
       (item) => item.symbol === symbolToMove
     );
@@ -610,7 +614,9 @@ export function WatchlistCard() {
   };
 
   function openEditDialog(item: WatchlistItemWithPrice) {
-    const sourceItem = items.find((candidate) => candidate.symbol === item.symbol);
+    const sourceItem = items.find(
+      (candidate) => candidate.symbol === item.symbol
+    );
     if (!sourceItem) return;
 
     setEditingItem(sourceItem);
@@ -667,7 +673,7 @@ export function WatchlistCard() {
       <CardContent>
         <form onSubmit={onAdd} className='mb-4 grid gap-2 sm:grid-cols-4'>
           <Input
-            placeholder='Add symbol (1-5 letters, e.g., MSFT)'
+            placeholder='Add symbol (e.g., MSFT or 0700.HK)'
             value={symbol}
             onChange={(e) => {
               setSymbol(e.target.value.toUpperCase());

--- a/src/features/stock-dashboard/components/__tests__/dashboard-readiness-panel.test.tsx
+++ b/src/features/stock-dashboard/components/__tests__/dashboard-readiness-panel.test.tsx
@@ -31,8 +31,8 @@ function buildDiagnostics(
         remediation: 'Configure Supabase.'
       },
       {
-        id: 'longbridge',
-        title: 'Longbridge',
+        id: 'market-data',
+        title: 'Market data',
         status: 'warning',
         summary: 'Market data credentials need review.',
         details: [],
@@ -44,18 +44,18 @@ function buildDiagnostics(
 }
 
 describe('DashboardReadinessPanel', () => {
-  it('renders Supabase and Longbridge setup guidance when checks need attention', () => {
+  it('renders Supabase and market data setup guidance when checks need attention', () => {
     render(<DashboardReadinessPanel diagnostics={buildDiagnostics()} />);
 
     expect(screen.getByText('Finish first-run setup')).toBeInTheDocument();
     expect(screen.getByText('Supabase')).toBeInTheDocument();
-    expect(screen.getByText('Longbridge')).toBeInTheDocument();
+    expect(screen.getByText('Market data')).toBeInTheDocument();
     expect(
       screen.getByRole('link', { name: /open operations/i })
     ).toHaveAttribute('href', '/dashboard/operations');
   });
 
-  it('does not render when Supabase and Longbridge are ready', () => {
+  it('does not render when Supabase and market data are ready', () => {
     const readyDiagnostics = buildDiagnostics({
       status: 'ready',
       checks: buildDiagnostics().checks.map((check) => ({

--- a/src/features/stock-dashboard/components/__tests__/quote-provider-toggle.test.tsx
+++ b/src/features/stock-dashboard/components/__tests__/quote-provider-toggle.test.tsx
@@ -14,12 +14,12 @@ describe('QuoteProviderToggle', () => {
     });
   });
 
-  it('shows Longbridge as the only visible provider option', () => {
+  it('shows the current provider in a source selector', () => {
     render(<QuoteProviderToggle />);
 
     expect(screen.getByText('Source:')).toBeInTheDocument();
-    expect(screen.getByText('Longbridge')).toBeInTheDocument();
-    expect(screen.queryByText('Default')).not.toBeInTheDocument();
-    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('combobox', { name: 'Quote data source' })
+    ).toHaveTextContent('Auto');
   });
 });

--- a/src/features/stock-dashboard/components/__tests__/watchlist-card.test.tsx
+++ b/src/features/stock-dashboard/components/__tests__/watchlist-card.test.tsx
@@ -210,14 +210,14 @@ describe('WatchlistCard add error modal flows', () => {
     (global.fetch as jest.Mock).mockClear();
 
     const input = screen.getByPlaceholderText(
-      'Add symbol (1-5 letters, e.g., MSFT)'
+      'Add symbol (e.g., MSFT or 0700.HK)'
     );
     await user.type(input, 'AAPL1');
     await user.click(screen.getByRole('button', { name: /^Add$/ }));
 
     expect(await screen.findByText('Invalid symbol')).toBeInTheDocument();
     expect(
-      screen.getByText('Ticker symbol must contain only letters')
+      screen.getByText('Ticker symbol must be 1-5 letters')
     ).toBeInTheDocument();
     expect(input).toHaveValue('AAPL1');
     expect(global.fetch).not.toHaveBeenCalled();
@@ -268,14 +268,14 @@ describe('WatchlistCard add error modal flows', () => {
     renderWithProviders(<WatchlistCard />);
 
     await user.type(
-      screen.getByPlaceholderText('Add symbol (1-5 letters, e.g., MSFT)'),
+      screen.getByPlaceholderText('Add symbol (e.g., MSFT or 0700.HK)'),
       'AAPL'
     );
     await user.click(screen.getByRole('button', { name: /^Add$/ }));
     await screen.findByText('AAPL');
 
     await user.type(
-      screen.getByPlaceholderText('Add symbol (1-5 letters, e.g., MSFT)'),
+      screen.getByPlaceholderText('Add symbol (e.g., MSFT or 0700.HK)'),
       'AAPL'
     );
     await user.click(screen.getByRole('button', { name: /^Add$/ }));
@@ -287,7 +287,7 @@ describe('WatchlistCard add error modal flows', () => {
       screen.getByText('That symbol is already in your watchlist.')
     ).toBeInTheDocument();
     expect(
-      screen.getByPlaceholderText('Add symbol (1-5 letters, e.g., MSFT)')
+      screen.getByPlaceholderText('Add symbol (e.g., MSFT or 0700.HK)')
     ).toHaveValue('AAPL');
     expect(addCalls).toBe(1);
   });
@@ -312,7 +312,7 @@ describe('WatchlistCard add error modal flows', () => {
     renderWithProviders(<WatchlistCard />);
 
     const input = screen.getByPlaceholderText(
-      'Add symbol (1-5 letters, e.g., MSFT)'
+      'Add symbol (e.g., MSFT or 0700.HK)'
     );
     await user.type(input, 'MSFT');
     await user.click(screen.getByRole('button', { name: /^Add$/ }));
@@ -325,25 +325,27 @@ describe('WatchlistCard add error modal flows', () => {
   });
 
   test('shows network modal when the request fails', async () => {
-    global.fetch = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = String(input);
-      if (url.endsWith('/api/watchlist') && (!init || !init.method)) {
-        return {
-          ok: true,
-          json: async () => watchlistResponse([])
-        } as any;
+    global.fetch = jest.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith('/api/watchlist') && (!init || !init.method)) {
+          return {
+            ok: true,
+            json: async () => watchlistResponse([])
+          } as any;
+        }
+        if (url.endsWith('/api/watchlist')) {
+          throw new Error('Network down');
+        }
+        throw new Error('Unexpected URL ' + url);
       }
-      if (url.endsWith('/api/watchlist')) {
-        throw new Error('Network down');
-      }
-      throw new Error('Unexpected URL ' + url);
-    }) as any;
+    ) as any;
 
     const user = userEvent.setup();
     renderWithProviders(<WatchlistCard />);
 
     const input = screen.getByPlaceholderText(
-      'Add symbol (1-5 letters, e.g., MSFT)'
+      'Add symbol (e.g., MSFT or 0700.HK)'
     );
     await user.type(input, 'TSLA');
     await user.click(screen.getByRole('button', { name: /^Add$/ }));
@@ -469,7 +471,7 @@ describe('WatchlistCard groups and metadata', () => {
 
     await screen.findByText('Build your watchlist');
     await user.type(
-      screen.getByPlaceholderText('Add symbol (1-5 letters, e.g., MSFT)'),
+      screen.getByPlaceholderText('Add symbol (e.g., MSFT or 0700.HK)'),
       'aapl'
     );
     await user.type(screen.getByPlaceholderText('Exchange'), 'nasdaq');

--- a/src/features/stock-dashboard/hooks/__tests__/useWatchlistPrices.test.tsx
+++ b/src/features/stock-dashboard/hooks/__tests__/useWatchlistPrices.test.tsx
@@ -91,10 +91,7 @@ async function waitFor(predicate: () => boolean, timeout = 2000) {
   }
 }
 
-async function waitForWithFakeTimers(
-  predicate: () => boolean,
-  timeout = 2000
-) {
+async function waitForWithFakeTimers(predicate: () => boolean, timeout = 2000) {
   const start = Date.now();
 
   while (!predicate()) {
@@ -420,7 +417,9 @@ describe('useWatchlistPrices', () => {
     await waitFor(() => MockBrowserWebSocket.instances.length === 1);
     const socket = MockBrowserWebSocket.instances[0];
 
-    expect(socket.url).toBe('ws://localhost/api/ws/prices?provider=longbridge');
+    expect(socket.url).toBe(
+      `ws://localhost/api/ws/prices?provider=${CANONICAL_QUOTE_PROVIDER}`
+    );
 
     act(() => {
       socket.open();

--- a/src/features/stock-dashboard/lib/__tests__/add-ticker-error.test.ts
+++ b/src/features/stock-dashboard/lib/__tests__/add-ticker-error.test.ts
@@ -4,12 +4,12 @@ describe('getAddTickerError', () => {
   it('maps validation failures with provided message', () => {
     const error = getAddTickerError({
       type: 'validation',
-      message: 'Ticker symbol must contain only letters'
+      message: 'Ticker symbol must be 1-5 letters'
     });
 
     expect(error.category).toBe('validation');
     expect(error.title).toBe(ADD_TICKER_ERROR_COPY.validation.title);
-    expect(error.message).toBe('Ticker symbol must contain only letters');
+    expect(error.message).toBe('Ticker symbol must be 1-5 letters');
     expect(error.nextStep).toBe(ADD_TICKER_ERROR_COPY.validation.nextStep);
     expect(error.source).toBe('client');
   });

--- a/src/features/stock-dashboard/lib/add-ticker-error.ts
+++ b/src/features/stock-dashboard/lib/add-ticker-error.ts
@@ -29,8 +29,8 @@ export const ADD_TICKER_ERROR_COPY: Record<
 > = {
   validation: {
     title: 'Invalid symbol',
-    message: 'Ticker symbols must be 1-5 letters.',
-    nextStep: 'Use 1-5 letters, like MSFT, and try again.'
+    message: 'Use a 1-5 letter symbol or a market suffix like 0700.HK.',
+    nextStep: 'Use a symbol like MSFT, AAPL.US, or 0700.HK and try again.'
   },
   duplicate: {
     title: 'Already in your watchlist',

--- a/src/features/stock-dashboard/store.test.ts
+++ b/src/features/stock-dashboard/store.test.ts
@@ -40,7 +40,7 @@ describe('dashboard provider state', () => {
     );
   });
 
-  it('migrates removed provider values to Longbridge', () => {
+  it('migrates removed provider values to auto routing', () => {
     localStorage.setItem('dashboard:quoteProvider', removedProvider);
 
     act(() => {
@@ -152,7 +152,9 @@ describe('dashboard provider state', () => {
       });
     });
 
-    expect(JSON.parse(localStorage.getItem(CHART_WORKSPACE_STORAGE_KEY)!)).toEqual({
+    expect(
+      JSON.parse(localStorage.getItem(CHART_WORKSPACE_STORAGE_KEY)!)
+    ).toEqual({
       symbol: 'NVDA',
       interval: 'month',
       range: '6m',

--- a/src/lib/diagnostics/setup.test.ts
+++ b/src/lib/diagnostics/setup.test.ts
@@ -51,7 +51,7 @@ describe('getSetupDiagnostics', () => {
     process.env = originalEnv;
   });
 
-  it('returns ready checks when Clerk, Supabase, and Longbridge are configured', async () => {
+  it('returns ready checks when Clerk, Supabase, and market data are configured', async () => {
     const diagnostics = await getSetupDiagnostics();
 
     expect(diagnostics.status).toBe('ready');
@@ -77,7 +77,7 @@ describe('getSetupDiagnostics', () => {
     expect(diagnostics.status).toBe('blocked');
     expect(findCheck(diagnostics, 'clerk').status).toBe('blocked');
     expect(findCheck(diagnostics, 'supabase').status).toBe('blocked');
-    expect(findCheck(diagnostics, 'longbridge').status).toBe('blocked');
+    expect(findCheck(diagnostics, 'market-data').status).toBe('warning');
     expect(JSON.stringify(diagnostics)).toContain(
       'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY'
     );
@@ -160,15 +160,19 @@ describe('getSetupDiagnostics', () => {
     );
   });
 
-  it('blocks Longbridge when any credential variable is missing', async () => {
+  it('warns when primary Longbridge credentials are missing', async () => {
     delete process.env.LONGPORT_ACCESS_TOKEN;
 
     const diagnostics = await getSetupDiagnostics();
 
-    const longbridge = findCheck(diagnostics, 'longbridge');
-    expect(longbridge.status).toBe('blocked');
-    expect(longbridge.details).toContain(
-      'Missing environment variables: LONGPORT_ACCESS_TOKEN.'
+    const marketData = findCheck(diagnostics, 'market-data');
+    expect(diagnostics.status).toBe('warning');
+    expect(marketData.status).toBe('warning');
+    expect(marketData.details).toContain(
+      'Missing Longbridge environment variables: LONGPORT_ACCESS_TOKEN.'
+    );
+    expect(marketData.details).toContain(
+      'Yahoo Finance fallback is available without server credentials.'
     );
     expect(JSON.stringify(diagnostics)).not.toContain('longbridge_app_secret');
   });

--- a/src/lib/diagnostics/setup.ts
+++ b/src/lib/diagnostics/setup.ts
@@ -5,7 +5,7 @@ import { SUPABASE_JWT_TEMPLATE } from '@/lib/supabase/server';
 
 export type DiagnosticStatus = 'ready' | 'warning' | 'blocked';
 
-export type DiagnosticCheckId = 'clerk' | 'supabase' | 'longbridge';
+export type DiagnosticCheckId = 'clerk' | 'supabase' | 'market-data';
 
 export interface SetupDiagnosticCheck {
   id: DiagnosticCheckId;
@@ -140,7 +140,9 @@ async function createSupabaseCheck(
   const hasLegacyAnonKey = hasEnvValue('NEXT_PUBLIC_SUPABASE_ANON_KEY');
 
   if (!hasEnvValue('NEXT_PUBLIC_SUPABASE_URL')) {
-    blockedReasons.push('Missing environment variable: NEXT_PUBLIC_SUPABASE_URL.');
+    blockedReasons.push(
+      'Missing environment variable: NEXT_PUBLIC_SUPABASE_URL.'
+    );
   } else if (!isValidUrl(supabaseUrl)) {
     blockedReasons.push(
       'NEXT_PUBLIC_SUPABASE_URL must be a valid absolute URL.'
@@ -169,7 +171,9 @@ async function createSupabaseCheck(
     );
   } else {
     try {
-      const token = await authState.getToken({ template: SUPABASE_JWT_TEMPLATE });
+      const token = await authState.getToken({
+        template: SUPABASE_JWT_TEMPLATE
+      });
 
       if (token?.trim()) {
         details.push(
@@ -212,7 +216,8 @@ async function createSupabaseCheck(
       id: 'supabase',
       title: 'Supabase',
       status: 'warning',
-      summary: 'Supabase config is present, but token verification is incomplete.',
+      summary:
+        'Supabase config is present, but token verification is incomplete.',
       details,
       remediation:
         'Retry while signed in. If the warning persists, confirm Clerk can issue the Supabase JWT template.'
@@ -229,30 +234,36 @@ async function createSupabaseCheck(
   };
 }
 
-function createLongbridgeCheck(): SetupDiagnosticCheck {
+function createMarketDataCheck(): SetupDiagnosticCheck {
   const missingKeys = getMissingEnvKeys(LONGBRIDGE_ENV_KEYS);
   const details =
     missingKeys.length > 0
-      ? [`Missing environment variables: ${joinKeys(missingKeys)}.`]
-      : ['Required Longbridge environment variables are present.'];
+      ? [
+          `Missing Longbridge environment variables: ${joinKeys(missingKeys)}.`,
+          'Yahoo Finance fallback is available without server credentials.'
+        ]
+      : [
+          'Required Longbridge environment variables are present.',
+          'Yahoo Finance fallback is available without server credentials.'
+        ];
 
   if (missingKeys.length > 0) {
     return {
-      id: 'longbridge',
-      title: 'Longbridge',
-      status: 'blocked',
-      summary: 'Market data credentials are incomplete.',
+      id: 'market-data',
+      title: 'Market data',
+      status: 'warning',
+      summary: 'Primary market data credentials are incomplete.',
       details,
       remediation:
-        'Configure Longbridge app key, app secret, and access token on the server.'
+        'Configure Longbridge app key, app secret, and access token to restore the primary provider.'
     };
   }
 
   return {
-    id: 'longbridge',
-    title: 'Longbridge',
+    id: 'market-data',
+    title: 'Market data',
     status: 'ready',
-    summary: 'Market data credentials are configured.',
+    summary: 'Market data providers are configured.',
     details,
     remediation: null
   };
@@ -303,7 +314,7 @@ export async function getSetupDiagnostics(): Promise<SetupDiagnostics> {
   const checks = [
     createClerkCheck(authState),
     await createSupabaseCheck(authState),
-    createLongbridgeCheck()
+    createMarketDataCheck()
   ];
   const status = getOverallStatus(checks);
 

--- a/src/lib/providers/__tests__/factory.test.ts
+++ b/src/lib/providers/__tests__/factory.test.ts
@@ -1,31 +1,37 @@
 import { StockProviderFactory } from '../factory';
 import {
+  AUTO_QUOTE_PROVIDER,
   CANONICAL_QUOTE_PROVIDER,
   LEGACY_DEFAULT_QUOTE_PROVIDER,
+  LONGBRIDGE_QUOTE_PROVIDER,
+  YAHOO_QUOTE_PROVIDER,
   migrateStoredQuoteProvider,
   resolveQuoteProvider
 } from '../config';
+import { getProviderRoutingPlan } from '../registry';
 import { LongbridgeProvider } from '../longbridge';
+import { YahooFinanceProvider } from '../yahoo-finance';
 
-jest.mock('../longbridge', () => ({
-  LongbridgeProvider: jest.fn().mockImplementation(() => ({
-    name: 'Longbridge'
-  }))
-}));
-
-const MockedLongbridgeProvider = LongbridgeProvider as jest.MockedClass<
-  typeof LongbridgeProvider
->;
 const removedProvider = ['alpha', 'vantage'].join('');
 
 describe('provider config', () => {
-  it('resolves the canonical provider from omitted input', () => {
-    expect(resolveQuoteProvider()).toBe(CANONICAL_QUOTE_PROVIDER);
+  it('resolves omitted input to the auto provider', () => {
+    expect(resolveQuoteProvider()).toBe(AUTO_QUOTE_PROVIDER);
+    expect(CANONICAL_QUOTE_PROVIDER).toBe(AUTO_QUOTE_PROVIDER);
   });
 
-  it('resolves the legacy default alias to Longbridge', () => {
+  it('resolves the legacy default alias to auto fallback routing', () => {
     expect(resolveQuoteProvider(LEGACY_DEFAULT_QUOTE_PROVIDER)).toBe(
-      CANONICAL_QUOTE_PROVIDER
+      AUTO_QUOTE_PROVIDER
+    );
+  });
+
+  it('resolves concrete provider IDs', () => {
+    expect(resolveQuoteProvider(LONGBRIDGE_QUOTE_PROVIDER)).toBe(
+      LONGBRIDGE_QUOTE_PROVIDER
+    );
+    expect(resolveQuoteProvider(YAHOO_QUOTE_PROVIDER)).toBe(
+      YAHOO_QUOTE_PROVIDER
     );
   });
 
@@ -34,35 +40,88 @@ describe('provider config', () => {
     expect(resolveQuoteProvider('legacy-provider')).toBeNull();
   });
 
-  it('migrates stored provider values to the canonical Longbridge value', () => {
+  it('migrates stored provider values to the auto provider by default', () => {
     expect(migrateStoredQuoteProvider(LEGACY_DEFAULT_QUOTE_PROVIDER)).toBe(
-      CANONICAL_QUOTE_PROVIDER
+      AUTO_QUOTE_PROVIDER
     );
     expect(migrateStoredQuoteProvider('legacy-provider')).toBe(
-      CANONICAL_QUOTE_PROVIDER
+      AUTO_QUOTE_PROVIDER
     );
   });
 });
 
+describe('provider routing', () => {
+  it('routes US symbols through Longbridge before Yahoo Finance', () => {
+    expect(
+      getProviderRoutingPlan({
+        symbol: 'AAPL',
+        operation: 'quote'
+      }).providers
+    ).toEqual([LONGBRIDGE_QUOTE_PROVIDER, YAHOO_QUOTE_PROVIDER]);
+  });
+
+  it('routes Mainland China symbols through Yahoo Finance before Longbridge', () => {
+    expect(
+      getProviderRoutingPlan({
+        symbol: '600000.SS',
+        operation: 'quote'
+      }).providers
+    ).toEqual([YAHOO_QUOTE_PROVIDER, LONGBRIDGE_QUOTE_PROVIDER]);
+  });
+
+  it('honors an explicit concrete provider request', () => {
+    expect(
+      getProviderRoutingPlan({
+        provider: YAHOO_QUOTE_PROVIDER,
+        symbol: 'AAPL',
+        operation: 'kline',
+        interval: 'week'
+      }).providers
+    ).toEqual([YAHOO_QUOTE_PROVIDER]);
+  });
+});
+
 describe('StockProviderFactory', () => {
-  beforeEach(() => {
-    MockedLongbridgeProvider.mockClear();
+  it('creates an auto fallback provider by default', () => {
+    const provider = StockProviderFactory.getProvider();
+
+    expect(provider).toEqual(
+      expect.objectContaining({
+        id: AUTO_QUOTE_PROVIDER,
+        name: 'Auto'
+      })
+    );
   });
 
-  it('creates a Longbridge provider for the canonical name', () => {
-    const provider = StockProviderFactory.getProvider(CANONICAL_QUOTE_PROVIDER);
+  it('creates a Longbridge provider for the concrete name', () => {
+    const provider = StockProviderFactory.getProvider(
+      LONGBRIDGE_QUOTE_PROVIDER
+    );
 
-    expect(MockedLongbridgeProvider).toHaveBeenCalledTimes(1);
-    expect(provider).toEqual({ name: 'Longbridge' });
+    expect(provider).toBeInstanceOf(LongbridgeProvider);
+    expect(provider).toEqual(expect.objectContaining({ name: 'Longbridge' }));
   });
 
-  it('creates a Longbridge provider for the default alias', () => {
+  it('creates a Yahoo Finance provider for the concrete name', () => {
+    const provider = StockProviderFactory.getProvider(YAHOO_QUOTE_PROVIDER);
+
+    expect(provider).toBeInstanceOf(YahooFinanceProvider);
+    expect(provider).toEqual(
+      expect.objectContaining({ name: 'Yahoo Finance' })
+    );
+  });
+
+  it('creates an auto fallback provider for the default alias', () => {
     const provider = StockProviderFactory.getProvider(
       LEGACY_DEFAULT_QUOTE_PROVIDER
     );
 
-    expect(MockedLongbridgeProvider).toHaveBeenCalledTimes(1);
-    expect(provider).toEqual({ name: 'Longbridge' });
+    expect(provider).toEqual(
+      expect.objectContaining({
+        id: AUTO_QUOTE_PROVIDER,
+        name: 'Auto'
+      })
+    );
   });
 
   it('throws INVALID_PROVIDER for unsupported values', () => {

--- a/src/lib/providers/__tests__/fallback-provider.test.ts
+++ b/src/lib/providers/__tests__/fallback-provider.test.ts
@@ -1,0 +1,205 @@
+import { FallbackStockDataProvider } from '../fallback-provider';
+import type { StockQuote, KLineSeries } from '../../types/stock-api';
+
+const mockQuote: StockQuote = {
+  symbol: 'AAPL',
+  name: 'Apple Inc.',
+  price: 150,
+  change: 1,
+  changePercent: 0.67,
+  volume: 1000,
+  high: 151,
+  low: 149,
+  open: 149.5,
+  previousClose: 149,
+  marketCap: null,
+  peRatio: null,
+  eps: null,
+  dividendYield: null,
+  week52High: null,
+  week52Low: null,
+  avgVolume: null,
+  beta: null,
+  lastUpdated: '2024-01-01T00:00:00.000Z'
+};
+
+const mockSeries: KLineSeries = {
+  symbol: 'AAPL',
+  range: {
+    startDate: '2024-01-01T00:00:00.000Z',
+    endDate: '2024-01-02T00:00:00.000Z',
+    interval: 'day'
+  },
+  candles: [
+    {
+      timestamp: 1704067200000,
+      open: 100,
+      high: 110,
+      low: 95,
+      close: 105,
+      volume: 1000
+    }
+  ],
+  lastUpdated: '2024-01-02T00:00:00.000Z'
+};
+
+const mockProviders = {
+  longbridge: {
+    id: 'longbridge',
+    name: 'Longbridge',
+    capabilities: {},
+    getQuote: jest.fn(),
+    getKLines: jest.fn(),
+    healthCheck: jest.fn()
+  },
+  yahoo: {
+    id: 'yahoo',
+    name: 'Yahoo Finance',
+    capabilities: {},
+    getQuote: jest.fn(),
+    getKLines: jest.fn(),
+    healthCheck: jest.fn()
+  }
+};
+
+const mockCreateRegisteredProvider = jest.fn(
+  (id: 'longbridge' | 'yahoo') => mockProviders[id]
+);
+const mockGetProviderRoutingPlan = jest.fn(() => ({
+  requestedProvider: 'auto',
+  operation: 'quote',
+  symbol: 'AAPL',
+  market: 'US',
+  providers: ['longbridge', 'yahoo'],
+  reason: 'test route'
+}));
+
+jest.mock('../registry', () => ({
+  createRegisteredProvider: (id: 'longbridge' | 'yahoo') =>
+    mockCreateRegisteredProvider(id),
+  getFallbackOrder: () => ['longbridge', 'yahoo'],
+  getProviderRoutingPlan: (...args: unknown[]) =>
+    mockGetProviderRoutingPlan(...args),
+  listProviderMetadata: () => [
+    {
+      id: 'longbridge',
+      name: 'Longbridge',
+      label: 'Longbridge',
+      fallbackRank: 10,
+      capabilities: {
+        quotes: true,
+        kLines: true,
+        realtime: 'polling',
+        intervals: ['day', 'week', 'month', 'year'],
+        markets: ['US'],
+        requiresCredentials: true
+      }
+    },
+    {
+      id: 'yahoo',
+      name: 'Yahoo Finance',
+      label: 'Yahoo Finance',
+      fallbackRank: 20,
+      capabilities: {
+        quotes: true,
+        kLines: true,
+        realtime: 'polling',
+        intervals: ['day', 'week', 'month', 'year'],
+        markets: ['US', 'GLOBAL'],
+        requiresCredentials: false
+      }
+    }
+  ]
+}));
+
+jest.mock('../../logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn()
+  }
+}));
+
+describe('FallbackStockDataProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockProviders.longbridge.getQuote.mockReset();
+    mockProviders.longbridge.getKLines.mockReset();
+    mockProviders.yahoo.getQuote.mockReset();
+    mockProviders.yahoo.getKLines.mockReset();
+    mockGetProviderRoutingPlan.mockReturnValue({
+      requestedProvider: 'auto',
+      operation: 'quote',
+      symbol: 'AAPL',
+      market: 'US',
+      providers: ['longbridge', 'yahoo'],
+      reason: 'test route'
+    });
+  });
+
+  it('falls back to the next provider when the primary provider fails', async () => {
+    mockProviders.longbridge.getQuote.mockRejectedValue({
+      code: 'INVALID_API_KEY',
+      message: 'Longbridge credentials not configured'
+    });
+    mockProviders.yahoo.getQuote.mockResolvedValue(mockQuote);
+
+    await expect(
+      new FallbackStockDataProvider().getQuote('AAPL')
+    ).resolves.toBe(mockQuote);
+
+    expect(mockProviders.longbridge.getQuote).toHaveBeenCalledWith('AAPL');
+    expect(mockProviders.yahoo.getQuote).toHaveBeenCalledWith('AAPL');
+  });
+
+  it('includes routing and attempt metadata when every provider fails', async () => {
+    mockProviders.longbridge.getQuote.mockRejectedValue({
+      code: 'INVALID_API_KEY',
+      message: 'Longbridge credentials not configured'
+    });
+    mockProviders.yahoo.getQuote.mockRejectedValue({
+      code: 'NETWORK_ERROR',
+      message: 'Yahoo Finance network request failed'
+    });
+
+    await expect(
+      new FallbackStockDataProvider().getQuote('AAPL')
+    ).rejects.toEqual(
+      expect.objectContaining({
+        code: 'NETWORK_ERROR',
+        details: expect.objectContaining({
+          providerFallback: expect.objectContaining({
+            route: ['longbridge', 'yahoo'],
+            attempts: [
+              expect.objectContaining({ providerId: 'longbridge' }),
+              expect.objectContaining({ providerId: 'yahoo' })
+            ]
+          })
+        })
+      })
+    );
+  });
+
+  it('routes k-line requests with the requested interval', async () => {
+    mockGetProviderRoutingPlan.mockReturnValue({
+      requestedProvider: 'auto',
+      operation: 'kline',
+      symbol: 'AAPL',
+      market: 'US',
+      providers: ['yahoo'],
+      reason: 'test kline route'
+    });
+    mockProviders.yahoo.getKLines.mockResolvedValue(mockSeries);
+
+    await expect(
+      new FallbackStockDataProvider().getKLines('AAPL', 'day')
+    ).resolves.toBe(mockSeries);
+
+    expect(mockGetProviderRoutingPlan).toHaveBeenCalledWith({
+      provider: 'auto',
+      symbol: 'AAPL',
+      operation: 'kline',
+      interval: 'day'
+    });
+    expect(mockProviders.yahoo.getKLines).toHaveBeenCalledWith('AAPL', 'day');
+  });
+});

--- a/src/lib/providers/__tests__/yahoo-finance.test.ts
+++ b/src/lib/providers/__tests__/yahoo-finance.test.ts
@@ -1,0 +1,147 @@
+import { YahooFinanceProvider } from '../yahoo-finance';
+
+function createYahooResponse(payload: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status >= 200 && status < 300 ? 'OK' : 'Upstream error',
+    headers: {
+      get: jest.fn()
+    },
+    json: async () => payload
+  } as unknown as Response;
+}
+
+function chartPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    chart: {
+      result: [
+        {
+          meta: {
+            symbol: 'AAPL',
+            longName: 'Apple Inc.',
+            regularMarketPrice: 105,
+            previousClose: 100,
+            regularMarketDayHigh: 110,
+            regularMarketDayLow: 95,
+            regularMarketOpen: 101,
+            regularMarketVolume: 1234,
+            regularMarketTime: 1704153600,
+            ...overrides
+          },
+          timestamp: [1704067200, 1704153600],
+          indicators: {
+            quote: [
+              {
+                open: [100, 101],
+                high: [106, 110],
+                low: [99, 95],
+                close: [104, 105],
+                volume: [1000, 1234]
+              }
+            ]
+          }
+        }
+      ],
+      error: null
+    }
+  };
+}
+
+describe('YahooFinanceProvider', () => {
+  it('transforms chart metadata into a stock quote', async () => {
+    const fetchImpl = jest.fn(async () => createYahooResponse(chartPayload()));
+    const provider = new YahooFinanceProvider({ fetchImpl: fetchImpl as any });
+
+    const quote = await provider.getQuote('AAPL.US');
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      expect.stringContaining('/AAPL?range=5d&interval=1d'),
+      { cache: 'no-store' }
+    );
+    expect(quote).toEqual(
+      expect.objectContaining({
+        symbol: 'AAPL.US',
+        name: 'Apple Inc.',
+        price: 105,
+        change: 5,
+        changePercent: 5,
+        volume: 1234,
+        previousClose: 100,
+        lastUpdated: '2024-01-02T00:00:00.000Z'
+      })
+    );
+  });
+
+  it('aggregates monthly candles into yearly k-line candles', async () => {
+    const fetchImpl = jest.fn(async () =>
+      createYahooResponse({
+        chart: {
+          result: [
+            {
+              meta: { symbol: 'AAPL' },
+              timestamp: [1640995200, 1643673600, 1672531200],
+              indicators: {
+                quote: [
+                  {
+                    open: [10, 12, 20],
+                    high: [15, 18, 25],
+                    low: [9, 11, 19],
+                    close: [14, 17, 24],
+                    volume: [100, 200, 300]
+                  }
+                ]
+              }
+            }
+          ],
+          error: null
+        }
+      })
+    );
+    const provider = new YahooFinanceProvider({ fetchImpl: fetchImpl as any });
+
+    const series = await provider.getKLines('AAPL', 'year');
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      expect.stringContaining('/AAPL?range=max&interval=1mo'),
+      { cache: 'no-store' }
+    );
+    expect(series.candles).toEqual([
+      {
+        timestamp: Date.UTC(2022, 0, 1),
+        open: 10,
+        high: 18,
+        low: 9,
+        close: 17,
+        volume: 300
+      },
+      {
+        timestamp: Date.UTC(2023, 0, 1),
+        open: 20,
+        high: 25,
+        low: 19,
+        close: 24,
+        volume: 300
+      }
+    ]);
+  });
+
+  it('maps rate limits to API_LIMIT_EXCEEDED', async () => {
+    const fetchImpl = jest.fn(async () =>
+      createYahooResponse(
+        {
+          chart: {
+            result: null,
+            error: { code: 'Too Many Requests', description: 'rate limit' }
+          }
+        },
+        429
+      )
+    );
+    const provider = new YahooFinanceProvider({ fetchImpl: fetchImpl as any });
+
+    await expect(provider.getQuote('AAPL')).rejects.toMatchObject({
+      code: 'API_LIMIT_EXCEEDED'
+    });
+  });
+});

--- a/src/lib/providers/config.ts
+++ b/src/lib/providers/config.ts
@@ -1,12 +1,25 @@
-export const CANONICAL_QUOTE_PROVIDER = 'longbridge' as const;
+import type { ProviderId } from './types';
+
+export const AUTO_QUOTE_PROVIDER = 'auto' as const;
+export const LONGBRIDGE_QUOTE_PROVIDER = 'longbridge' as const;
+export const YAHOO_QUOTE_PROVIDER = 'yahoo' as const;
+export const CANONICAL_QUOTE_PROVIDER = AUTO_QUOTE_PROVIDER;
 export const LEGACY_DEFAULT_QUOTE_PROVIDER = 'default' as const;
 
-export type CanonicalQuoteProvider = typeof CANONICAL_QUOTE_PROVIDER;
+export type CanonicalQuoteProvider = ProviderId;
 
 export const QUOTE_PROVIDER_OPTIONS = [
   {
-    value: CANONICAL_QUOTE_PROVIDER,
+    value: AUTO_QUOTE_PROVIDER,
+    label: 'Auto'
+  },
+  {
+    value: LONGBRIDGE_QUOTE_PROVIDER,
     label: 'Longbridge'
+  },
+  {
+    value: YAHOO_QUOTE_PROVIDER,
+    label: 'Yahoo Finance'
   }
 ] as const;
 
@@ -15,27 +28,24 @@ function normalizeProviderValue(value?: string | null): string | null {
   return normalized ? normalized : null;
 }
 
-export function resolveQuoteProvider(
-  value?: string | null
-): CanonicalQuoteProvider | null {
+export function resolveQuoteProvider(value?: string | null): ProviderId | null {
   const normalized = normalizeProviderValue(value);
 
   if (!normalized) {
     return CANONICAL_QUOTE_PROVIDER;
   }
 
-  if (
-    normalized === CANONICAL_QUOTE_PROVIDER ||
-    normalized === LEGACY_DEFAULT_QUOTE_PROVIDER
-  ) {
+  if (normalized === LEGACY_DEFAULT_QUOTE_PROVIDER) {
     return CANONICAL_QUOTE_PROVIDER;
   }
 
-  return null;
+  const provider = QUOTE_PROVIDER_OPTIONS.find(
+    (option) => option.value === normalized
+  );
+
+  return provider?.value ?? null;
 }
 
-export function migrateStoredQuoteProvider(
-  value?: string | null
-): CanonicalQuoteProvider {
+export function migrateStoredQuoteProvider(value?: string | null): ProviderId {
   return resolveQuoteProvider(value) ?? CANONICAL_QUOTE_PROVIDER;
 }

--- a/src/lib/providers/factory.ts
+++ b/src/lib/providers/factory.ts
@@ -1,19 +1,91 @@
-import { StockDataProvider } from './types';
-import { LongbridgeProvider } from './longbridge';
+import {
+  ProviderHealthReport,
+  ProviderMetadata,
+  StockDataProvider
+} from './types';
 import { APIError } from '../types/stock-api';
-import { resolveQuoteProvider } from './config';
+import { AUTO_QUOTE_PROVIDER } from './config';
+import { FallbackStockDataProvider } from './fallback-provider';
+import {
+  createRegisteredProvider,
+  getFallbackOrder,
+  listProviderMetadata,
+  resolveProviderOrThrow
+} from './registry';
 
 export class StockProviderFactory {
   static getProvider(name?: string | null): StockDataProvider {
-    const provider = resolveQuoteProvider(name);
+    const provider = resolveProviderOrThrow(name);
 
-    if (!provider) {
-      throw {
-        code: 'INVALID_PROVIDER',
-        message: `Unsupported provider: ${name}`
-      } as APIError;
+    if (provider === AUTO_QUOTE_PROVIDER) {
+      return new FallbackStockDataProvider();
     }
 
-    return new LongbridgeProvider();
+    return createRegisteredProvider(provider);
   }
+
+  static listProviders(): ProviderMetadata[] {
+    return listProviderMetadata();
+  }
+
+  static getFallbackOrder() {
+    return getFallbackOrder();
+  }
+
+  static async getProviderHealthReport(): Promise<ProviderHealthReport> {
+    const checkedAt = new Date().toISOString();
+    const checks = await Promise.all(
+      getFallbackOrder().map(async (providerId) => {
+        try {
+          return await createRegisteredProvider(providerId).healthCheck();
+        } catch (error) {
+          const apiError = isAPIError(error)
+            ? error
+            : ({
+                code: 'UNKNOWN_ERROR',
+                message:
+                  error instanceof Error
+                    ? error.message
+                    : 'Provider health check failed'
+              } as APIError);
+
+          return {
+            provider: providerId,
+            providerId,
+            status: 'degraded' as const,
+            latencyMs: 0,
+            checkedAt,
+            details: {
+              code: apiError.code,
+              message: apiError.message
+            }
+          };
+        }
+      })
+    );
+    const status = checks.some((check) => check.status === 'healthy')
+      ? 'healthy'
+      : checks.some((check) => check.status === 'degraded')
+        ? 'degraded'
+        : 'unconfigured';
+
+    return {
+      provider: 'Auto',
+      providerId: AUTO_QUOTE_PROVIDER,
+      status,
+      checkedAt,
+      fallbackOrder: getFallbackOrder(),
+      providers: checks,
+      metadata: listProviderMetadata()
+    };
+  }
+}
+
+function isAPIError(error: unknown): error is APIError {
+  return (
+    error !== null &&
+    typeof error === 'object' &&
+    'code' in error &&
+    'message' in error
+  );
 }

--- a/src/lib/providers/fallback-provider.ts
+++ b/src/lib/providers/fallback-provider.ts
@@ -1,0 +1,238 @@
+import { logger } from '../logger';
+import {
+  APIError,
+  DEFAULT_KLINE_INTERVAL,
+  type KLineInterval,
+  KLineSeries,
+  StockQuote
+} from '../types/stock-api';
+import { AUTO_QUOTE_PROVIDER } from './config';
+import {
+  createRegisteredProvider,
+  getFallbackOrder,
+  getProviderRoutingPlan,
+  listProviderMetadata
+} from './registry';
+import {
+  ConcreteProviderId,
+  ProviderCapabilities,
+  ProviderFallbackAttempt,
+  ProviderHealthCheck,
+  StockDataProvider
+} from './types';
+
+const AUTO_PROVIDER_CAPABILITIES: ProviderCapabilities = {
+  quotes: true,
+  kLines: true,
+  realtime: 'polling',
+  intervals: ['day', 'week', 'month', 'year'],
+  markets: Array.from(
+    new Set(
+      listProviderMetadata().flatMap(
+        (provider) => provider.capabilities.markets
+      )
+    )
+  ),
+  requiresCredentials: false
+};
+
+export class FallbackStockDataProvider implements StockDataProvider {
+  id = AUTO_QUOTE_PROVIDER;
+  name = 'Auto';
+  capabilities = AUTO_PROVIDER_CAPABILITIES;
+
+  async getQuote(symbol: string): Promise<StockQuote> {
+    const plan = getProviderRoutingPlan({
+      provider: AUTO_QUOTE_PROVIDER,
+      symbol,
+      operation: 'quote'
+    });
+
+    return this.executeWithFallback(
+      plan.providers,
+      (provider) => provider.getQuote(symbol),
+      {
+        symbol: plan.symbol,
+        operation: 'quote',
+        market: plan.market,
+        reason: plan.reason
+      }
+    );
+  }
+
+  async getKLines(
+    symbol: string,
+    interval: KLineInterval = DEFAULT_KLINE_INTERVAL
+  ): Promise<KLineSeries> {
+    const plan = getProviderRoutingPlan({
+      provider: AUTO_QUOTE_PROVIDER,
+      symbol,
+      operation: 'kline',
+      interval
+    });
+
+    return this.executeWithFallback(
+      plan.providers,
+      (provider) => provider.getKLines(symbol, interval),
+      {
+        symbol: plan.symbol,
+        operation: 'kline',
+        market: plan.market,
+        reason: plan.reason,
+        interval
+      }
+    );
+  }
+
+  async healthCheck(): Promise<ProviderHealthCheck> {
+    const startedAt = Date.now();
+    const checkedAt = new Date(startedAt).toISOString();
+    const checks = await Promise.all(
+      getFallbackOrder().map(async (providerId) => {
+        try {
+          return await createRegisteredProvider(providerId).healthCheck();
+        } catch (error) {
+          const apiError = this.toAPIError(error);
+          return {
+            provider: providerId,
+            providerId,
+            status: 'degraded',
+            latencyMs: 0,
+            checkedAt,
+            details: {
+              code: apiError.code,
+              message: apiError.message
+            }
+          } as ProviderHealthCheck;
+        }
+      })
+    );
+    const status = checks.some((check) => check.status === 'healthy')
+      ? 'healthy'
+      : checks.some((check) => check.status === 'degraded')
+        ? 'degraded'
+        : 'unconfigured';
+
+    return {
+      provider: this.name,
+      providerId: this.id,
+      status,
+      latencyMs: Math.max(0, Date.now() - startedAt),
+      checkedAt,
+      details: {
+        fallbackOrder: getFallbackOrder(),
+        providers: checks.map((check) => ({
+          providerId: check.providerId,
+          provider: check.provider,
+          status: check.status
+        }))
+      }
+    };
+  }
+
+  private async executeWithFallback<T>(
+    providerIds: ConcreteProviderId[],
+    operation: (provider: StockDataProvider) => Promise<T>,
+    context: {
+      symbol: string;
+      operation: 'quote' | 'kline';
+      market: string;
+      reason: string;
+      interval?: KLineInterval;
+    }
+  ): Promise<T> {
+    const attempts: ProviderFallbackAttempt[] = [];
+    let selectedError: APIError | null = null;
+
+    for (let index = 0; index < providerIds.length; index += 1) {
+      const providerId = providerIds[index];
+      const provider = createRegisteredProvider(providerId);
+
+      try {
+        return await operation(provider);
+      } catch (error) {
+        const apiError = this.toAPIError(error);
+        selectedError = chooseFallbackError(selectedError, apiError);
+        attempts.push({
+          providerId,
+          provider: provider.name,
+          code: apiError.code,
+          message: apiError.message
+        });
+
+        if (index < providerIds.length - 1) {
+          logger.info('Market data provider failed; trying fallback', {
+            providerId,
+            symbol: context.symbol,
+            operation: context.operation,
+            code: apiError.code,
+            message: apiError.message
+          });
+        }
+      }
+    }
+
+    const error = selectedError ?? {
+      code: 'UNKNOWN_ERROR',
+      message: 'Market data provider failed'
+    };
+
+    throw {
+      code: error.code,
+      message: `All market data providers failed for ${context.symbol}: ${error.message}`,
+      details: {
+        ...error.details,
+        providerFallback: {
+          requestedProvider: AUTO_QUOTE_PROVIDER,
+          symbol: context.symbol,
+          operation: context.operation,
+          market: context.market,
+          interval: context.interval,
+          route: providerIds,
+          reason: context.reason,
+          attempts
+        }
+      }
+    } as APIError;
+  }
+
+  private toAPIError(error: unknown): APIError {
+    if (
+      error !== null &&
+      typeof error === 'object' &&
+      'code' in error &&
+      'message' in error
+    ) {
+      return error as APIError;
+    }
+
+    return {
+      code: 'UNKNOWN_ERROR',
+      message:
+        error instanceof Error ? error.message : 'Market data provider failed'
+    };
+  }
+}
+
+function chooseFallbackError(
+  current: APIError | null,
+  next: APIError
+): APIError {
+  if (!current) {
+    return next;
+  }
+
+  if (current.code === 'INVALID_API_KEY' && next.code !== 'INVALID_API_KEY') {
+    return next;
+  }
+
+  if (next.code === 'API_LIMIT_EXCEEDED') {
+    return next;
+  }
+
+  if (current.code === 'UNKNOWN_ERROR' && next.code !== 'UNKNOWN_ERROR') {
+    return next;
+  }
+
+  return current;
+}

--- a/src/lib/providers/longbridge.ts
+++ b/src/lib/providers/longbridge.ts
@@ -8,7 +8,12 @@ import {
   TimeRange
 } from '../types/stock-api';
 import { logger } from '../logger';
-import { ProviderHealthCheck, StockDataProvider } from './types';
+import {
+  ProviderCapabilities,
+  ProviderHealthCheck,
+  StockDataProvider
+} from './types';
+import { LONGBRIDGE_QUOTE_PROVIDER } from './config';
 import {
   Config,
   QuoteContext,
@@ -33,6 +38,15 @@ const LONG_BRIDGE_RETRY_MAX_DELAY_MS = 2000;
 const LONG_BRIDGE_HEALTH_CACHE_TTL_MS = 30_000;
 const LONG_BRIDGE_HEALTH_SYMBOL = 'AAPL.US';
 
+export const LONGBRIDGE_PROVIDER_CAPABILITIES: ProviderCapabilities = {
+  quotes: true,
+  kLines: true,
+  realtime: 'polling',
+  intervals: ['day', 'week', 'month', 'year'],
+  markets: ['US', 'HK', 'CN'],
+  requiresCredentials: true
+};
+
 // Longbridge exposes const-enum Period values where 17 is Quarter and 18 is Year.
 const LONG_BRIDGE_PERIOD_MAP: Record<KLineInterval, number> = {
   day: 14,
@@ -56,7 +70,9 @@ interface ExecuteOptions {
 }
 
 export class LongbridgeProvider implements StockDataProvider {
+  id = LONGBRIDGE_QUOTE_PROVIDER;
   name = 'Longbridge';
+  capabilities = LONGBRIDGE_PROVIDER_CAPABILITIES;
   private static healthCache:
     | {
         expiresAt: number;
@@ -216,6 +232,7 @@ export class LongbridgeProvider implements StockDataProvider {
     if (!this.hasCredentials()) {
       return {
         provider: this.name,
+        providerId: this.id,
         status: 'unconfigured',
         latencyMs: 0,
         checkedAt,
@@ -249,6 +266,7 @@ export class LongbridgeProvider implements StockDataProvider {
 
       return {
         provider: this.name,
+        providerId: this.id,
         status: 'healthy',
         latencyMs: Math.max(0, this.now() - startedAt),
         checkedAt,
@@ -264,6 +282,7 @@ export class LongbridgeProvider implements StockDataProvider {
 
       return {
         provider: this.name,
+        providerId: this.id,
         status:
           apiError.code === 'INVALID_API_KEY' ? 'unconfigured' : 'degraded',
         latencyMs: Math.max(0, this.now() - startedAt),

--- a/src/lib/providers/registry.ts
+++ b/src/lib/providers/registry.ts
@@ -1,0 +1,266 @@
+import {
+  AUTO_QUOTE_PROVIDER,
+  LONGBRIDGE_QUOTE_PROVIDER,
+  YAHOO_QUOTE_PROVIDER,
+  resolveQuoteProvider
+} from './config';
+import {
+  ConcreteProviderId,
+  ProviderId,
+  ProviderMetadata,
+  ProviderOperation,
+  ProviderRoutingPlan,
+  StockDataProvider
+} from './types';
+import {
+  LongbridgeProvider,
+  LONGBRIDGE_PROVIDER_CAPABILITIES
+} from './longbridge';
+import {
+  YahooFinanceProvider,
+  YAHOO_PROVIDER_CAPABILITIES
+} from './yahoo-finance';
+import { APIError, type KLineInterval } from '../types/stock-api';
+
+interface ProviderRegistryEntry extends ProviderMetadata {
+  createProvider: () => StockDataProvider;
+}
+
+interface SymbolRoute {
+  market: string;
+  matches: (symbol: string) => boolean;
+  providers: ConcreteProviderId[];
+  reason: string;
+}
+
+const PROVIDER_REGISTRY: ProviderRegistryEntry[] = [
+  {
+    id: LONGBRIDGE_QUOTE_PROVIDER,
+    name: 'Longbridge',
+    label: 'Longbridge',
+    fallbackRank: 10,
+    capabilities: LONGBRIDGE_PROVIDER_CAPABILITIES,
+    createProvider: () => new LongbridgeProvider()
+  },
+  {
+    id: YAHOO_QUOTE_PROVIDER,
+    name: 'Yahoo Finance',
+    label: 'Yahoo Finance',
+    fallbackRank: 20,
+    capabilities: YAHOO_PROVIDER_CAPABILITIES,
+    createProvider: () => new YahooFinanceProvider()
+  }
+];
+
+const SYMBOL_ROUTES: SymbolRoute[] = [
+  {
+    market: 'US',
+    matches: (symbol) => isBareUSSymbol(symbol) || symbol.endsWith('.US'),
+    providers: [LONGBRIDGE_QUOTE_PROVIDER, YAHOO_QUOTE_PROVIDER],
+    reason: 'US symbols prefer Longbridge with Yahoo Finance fallback.'
+  },
+  {
+    market: 'HK',
+    matches: (symbol) => symbol.endsWith('.HK'),
+    providers: [LONGBRIDGE_QUOTE_PROVIDER, YAHOO_QUOTE_PROVIDER],
+    reason: 'Hong Kong symbols prefer Longbridge with Yahoo Finance fallback.'
+  },
+  {
+    market: 'CN',
+    matches: (symbol) =>
+      symbol.endsWith('.SS') ||
+      symbol.endsWith('.SZ') ||
+      symbol.endsWith('.CN'),
+    providers: [YAHOO_QUOTE_PROVIDER, LONGBRIDGE_QUOTE_PROVIDER],
+    reason:
+      'Mainland China symbols prefer Yahoo Finance with Longbridge fallback.'
+  },
+  {
+    market: 'GLOBAL',
+    matches: () => true,
+    providers: [YAHOO_QUOTE_PROVIDER, LONGBRIDGE_QUOTE_PROVIDER],
+    reason:
+      'Unqualified global symbols prefer Yahoo Finance with Longbridge fallback.'
+  }
+];
+
+export function listProviderMetadata(): ProviderMetadata[] {
+  return PROVIDER_REGISTRY.map((provider) => ({
+    id: provider.id,
+    name: provider.name,
+    label: provider.label,
+    fallbackRank: provider.fallbackRank,
+    capabilities: provider.capabilities
+  }));
+}
+
+export function getFallbackOrder(): ConcreteProviderId[] {
+  return [...PROVIDER_REGISTRY]
+    .sort((a, b) => a.fallbackRank - b.fallbackRank)
+    .map((provider) => provider.id);
+}
+
+export function createRegisteredProvider(
+  id: ConcreteProviderId
+): StockDataProvider {
+  const entry = getProviderEntry(id);
+  return entry.createProvider();
+}
+
+export function getProviderRoutingPlan(options: {
+  provider?: string | null;
+  symbol: string;
+  operation: ProviderOperation;
+  interval?: KLineInterval;
+}): ProviderRoutingPlan {
+  const requestedProvider = resolveProviderOrThrow(options.provider);
+  const symbol = normalizeSymbol(options.symbol);
+
+  if (requestedProvider !== AUTO_QUOTE_PROVIDER) {
+    const entry = getProviderEntry(requestedProvider);
+    assertSupportsOperation(entry, options.operation, options.interval);
+
+    return {
+      requestedProvider,
+      operation: options.operation,
+      symbol,
+      market: getMarketForSymbol(symbol),
+      providers: [requestedProvider],
+      reason: `Explicit provider requested: ${entry.label}.`
+    };
+  }
+
+  const route = getSymbolRoute(symbol);
+  const routedProviders = route.providers.filter((id) =>
+    providerSupports(id, route.market, options.operation, options.interval)
+  );
+  const fallbackProviders = getFallbackOrder().filter(
+    (id) =>
+      !routedProviders.includes(id) &&
+      providerSupports(id, route.market, options.operation, options.interval)
+  );
+  const providers = [...routedProviders, ...fallbackProviders];
+
+  if (providers.length === 0) {
+    throw {
+      code: 'INVALID_PROVIDER',
+      message: `No market data providers support ${options.operation} for ${symbol}`,
+      details: {
+        symbol,
+        operation: options.operation,
+        market: route.market
+      }
+    } as APIError;
+  }
+
+  return {
+    requestedProvider,
+    operation: options.operation,
+    symbol,
+    market: route.market,
+    providers,
+    reason: route.reason
+  };
+}
+
+export function resolveProviderOrThrow(value?: string | null): ProviderId {
+  const provider = resolveQuoteProvider(value);
+
+  if (!provider) {
+    throw {
+      code: 'INVALID_PROVIDER',
+      message: `Unsupported provider: ${value}`
+    } as APIError;
+  }
+
+  return provider;
+}
+
+function getProviderEntry(id: ConcreteProviderId): ProviderRegistryEntry {
+  const entry = PROVIDER_REGISTRY.find((provider) => provider.id === id);
+
+  if (!entry) {
+    throw {
+      code: 'INVALID_PROVIDER',
+      message: `Unsupported provider: ${id}`
+    } as APIError;
+  }
+
+  return entry;
+}
+
+function providerSupports(
+  id: ConcreteProviderId,
+  market: string,
+  operation: ProviderOperation,
+  interval?: KLineInterval
+): boolean {
+  const entry = getProviderEntry(id);
+  const supportsMarket =
+    entry.capabilities.markets.includes(market) ||
+    entry.capabilities.markets.includes('GLOBAL');
+
+  return (
+    supportsMarket &&
+    supportsOperation(entry, operation) &&
+    supportsInterval(entry, operation, interval)
+  );
+}
+
+function assertSupportsOperation(
+  entry: ProviderRegistryEntry,
+  operation: ProviderOperation,
+  interval?: KLineInterval
+) {
+  if (
+    !supportsOperation(entry, operation) ||
+    !supportsInterval(entry, operation, interval)
+  ) {
+    throw {
+      code: 'INVALID_PROVIDER',
+      message: `${entry.label} does not support ${operation} requests`,
+      details: {
+        provider: entry.id,
+        operation,
+        interval
+      }
+    } as APIError;
+  }
+}
+
+function supportsOperation(
+  entry: ProviderRegistryEntry,
+  operation: ProviderOperation
+): boolean {
+  return operation === 'quote'
+    ? entry.capabilities.quotes
+    : entry.capabilities.kLines;
+}
+
+function supportsInterval(
+  entry: ProviderRegistryEntry,
+  operation: ProviderOperation,
+  interval?: KLineInterval
+): boolean {
+  if (operation !== 'kline' || !interval) {
+    return true;
+  }
+
+  return entry.capabilities.intervals.includes(interval);
+}
+
+function getSymbolRoute(symbol: string): SymbolRoute {
+  return SYMBOL_ROUTES.find((route) => route.matches(symbol))!;
+}
+
+function getMarketForSymbol(symbol: string): string {
+  return getSymbolRoute(symbol).market;
+}
+
+function normalizeSymbol(symbol: string): string {
+  return symbol.trim().toUpperCase();
+}
+
+function isBareUSSymbol(symbol: string): boolean {
+  return /^[A-Z]{1,5}$/.test(symbol);
+}

--- a/src/lib/providers/types.ts
+++ b/src/lib/providers/types.ts
@@ -5,10 +5,31 @@ import {
   StockQuote
 } from '../types/stock-api';
 
+export type ConcreteProviderId = 'longbridge' | 'yahoo';
+export type ProviderId = 'auto' | ConcreteProviderId;
+export type ProviderOperation = 'quote' | 'kline';
 export type ProviderHealthStatus = 'healthy' | 'degraded' | 'unconfigured';
+
+export interface ProviderCapabilities {
+  quotes: boolean;
+  kLines: boolean;
+  realtime: 'polling' | 'streaming' | 'none';
+  intervals: KLineInterval[];
+  markets: string[];
+  requiresCredentials: boolean;
+}
+
+export interface ProviderMetadata {
+  id: ConcreteProviderId;
+  name: string;
+  label: string;
+  fallbackRank: number;
+  capabilities: ProviderCapabilities;
+}
 
 export interface ProviderHealthCheck {
   provider: string;
+  providerId?: ProviderId;
   status: ProviderHealthStatus;
   latencyMs: number;
   checkedAt: string;
@@ -20,8 +41,36 @@ export interface ProviderHealthCheck {
   };
 }
 
+export interface ProviderRoutingPlan {
+  requestedProvider: ProviderId;
+  operation: ProviderOperation;
+  symbol: string;
+  market: string;
+  providers: ConcreteProviderId[];
+  reason: string;
+}
+
+export interface ProviderFallbackAttempt {
+  providerId: ConcreteProviderId;
+  provider: string;
+  code?: APIErrorCode;
+  message: string;
+}
+
+export interface ProviderHealthReport {
+  provider: 'Auto';
+  providerId: 'auto';
+  status: ProviderHealthStatus;
+  checkedAt: string;
+  fallbackOrder: ConcreteProviderId[];
+  providers: ProviderHealthCheck[];
+  metadata: ProviderMetadata[];
+}
+
 export interface StockDataProvider {
+  id: ProviderId;
   name: string;
+  capabilities: ProviderCapabilities;
   getQuote(symbol: string): Promise<StockQuote>;
   getKLines(symbol: string, interval?: KLineInterval): Promise<KLineSeries>;
   healthCheck(): Promise<ProviderHealthCheck>;

--- a/src/lib/providers/yahoo-finance.ts
+++ b/src/lib/providers/yahoo-finance.ts
@@ -1,0 +1,601 @@
+import {
+  APIError,
+  DEFAULT_KLINE_INTERVAL,
+  type KLineInterval,
+  KLineCandle,
+  KLineSeries,
+  StockQuote,
+  TimeRange
+} from '../types/stock-api';
+import {
+  ProviderCapabilities,
+  ProviderHealthCheck,
+  StockDataProvider
+} from './types';
+import { YAHOO_QUOTE_PROVIDER } from './config';
+
+const YAHOO_CHART_BASE_URL =
+  'https://query1.finance.yahoo.com/v8/finance/chart';
+const YAHOO_HEALTH_SYMBOL = 'AAPL';
+
+const YAHOO_KLINE_PARAMS: Record<
+  KLineInterval,
+  { range: string; interval: string; aggregateByYear?: boolean }
+> = {
+  day: { range: '2y', interval: '1d' },
+  week: { range: '5y', interval: '1wk' },
+  month: { range: '10y', interval: '1mo' },
+  year: { range: 'max', interval: '1mo', aggregateByYear: true }
+};
+
+export const YAHOO_PROVIDER_CAPABILITIES: ProviderCapabilities = {
+  quotes: true,
+  kLines: true,
+  realtime: 'polling',
+  intervals: ['day', 'week', 'month', 'year'],
+  markets: ['US', 'HK', 'CN', 'GLOBAL'],
+  requiresCredentials: false
+};
+
+interface YahooProviderOptions {
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+  healthSymbol?: string;
+}
+
+interface YahooChartResponse {
+  chart?: {
+    result?: YahooChartResult[] | null;
+    error?: YahooChartError | null;
+  };
+}
+
+interface YahooChartError {
+  code?: string;
+  description?: string;
+}
+
+interface YahooChartResult {
+  meta?: YahooChartMeta;
+  timestamp?: number[];
+  indicators?: {
+    quote?: YahooQuoteIndicator[];
+  };
+}
+
+interface YahooChartMeta {
+  symbol?: string;
+  shortName?: string;
+  longName?: string;
+  currency?: string;
+  regularMarketPrice?: number;
+  previousClose?: number;
+  chartPreviousClose?: number;
+  regularMarketDayHigh?: number;
+  regularMarketDayLow?: number;
+  regularMarketOpen?: number;
+  regularMarketVolume?: number;
+  regularMarketTime?: number;
+  fiftyTwoWeekHigh?: number;
+  fiftyTwoWeekLow?: number;
+}
+
+interface YahooQuoteIndicator {
+  open?: Array<number | null>;
+  high?: Array<number | null>;
+  low?: Array<number | null>;
+  close?: Array<number | null>;
+  volume?: Array<number | null>;
+}
+
+interface YahooChartFetchResult {
+  result: YahooChartResult;
+  yahooSymbol: string;
+}
+
+export class YahooFinanceProvider implements StockDataProvider {
+  id = YAHOO_QUOTE_PROVIDER;
+  name = 'Yahoo Finance';
+  capabilities = YAHOO_PROVIDER_CAPABILITIES;
+
+  private readonly fetchImpl: typeof fetch;
+  private readonly now: () => number;
+  private readonly healthSymbol: string;
+
+  constructor(options: YahooProviderOptions = {}) {
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.now = options.now ?? Date.now;
+    this.healthSymbol = options.healthSymbol ?? YAHOO_HEALTH_SYMBOL;
+  }
+
+  async getQuote(symbol: string): Promise<StockQuote> {
+    const { result } = await this.fetchChart(symbol, {
+      range: '5d',
+      interval: '1d'
+    });
+    const meta = result.meta ?? {};
+    const quote = result.indicators?.quote?.[0] ?? {};
+    const latestIndex = getLatestIndex(quote.close);
+    const price = firstNumber(
+      meta.regularMarketPrice,
+      getArrayNumber(quote.close, latestIndex)
+    );
+    const previousClose = firstNumber(
+      meta.previousClose,
+      meta.chartPreviousClose,
+      getPreviousNumber(quote.close, latestIndex)
+    );
+
+    if (price === undefined || previousClose === undefined) {
+      throw {
+        code: 'INVALID_SYMBOL',
+        message: `Yahoo Finance quote data was unavailable for ${symbol}`,
+        details: {
+          provider: this.id
+        }
+      } as APIError;
+    }
+
+    const change = price - previousClose;
+    const timestampSeconds = firstNumber(
+      meta.regularMarketTime,
+      getArrayNumber(result.timestamp, latestIndex)
+    );
+    const lastUpdated = timestampSeconds
+      ? new Date(timestampSeconds * 1000).toISOString()
+      : new Date(this.now()).toISOString();
+
+    return {
+      symbol: normalizeSymbol(symbol),
+      name: meta.longName ?? meta.shortName ?? normalizeSymbol(symbol),
+      price,
+      change,
+      changePercent: previousClose !== 0 ? (change / previousClose) * 100 : 0,
+      volume: firstNumber(
+        meta.regularMarketVolume,
+        getArrayNumber(quote.volume, latestIndex),
+        0
+      )!,
+      high: firstNumber(
+        meta.regularMarketDayHigh,
+        getArrayNumber(quote.high, latestIndex),
+        price
+      )!,
+      low: firstNumber(
+        meta.regularMarketDayLow,
+        getArrayNumber(quote.low, latestIndex),
+        price
+      )!,
+      open: firstNumber(
+        meta.regularMarketOpen,
+        getArrayNumber(quote.open, latestIndex),
+        price
+      )!,
+      previousClose,
+      marketCap: null,
+      peRatio: null,
+      eps: null,
+      dividendYield: null,
+      week52High: firstNumber(meta.fiftyTwoWeekHigh, null) ?? null,
+      week52Low: firstNumber(meta.fiftyTwoWeekLow, null) ?? null,
+      avgVolume: null,
+      beta: null,
+      lastUpdated
+    };
+  }
+
+  async getKLines(
+    symbol: string,
+    interval: KLineInterval = DEFAULT_KLINE_INTERVAL
+  ): Promise<KLineSeries> {
+    const params = YAHOO_KLINE_PARAMS[interval];
+    const { result } = await this.fetchChart(symbol, {
+      range: params.range,
+      interval: params.interval
+    });
+    const candles = this.transformChartResultToCandles(result);
+    const normalizedCandles = params.aggregateByYear
+      ? aggregateCandlesByYear(candles)
+      : candles;
+
+    if (normalizedCandles.length === 0) {
+      throw {
+        code: 'INVALID_SYMBOL',
+        message: `Yahoo Finance k-line data was unavailable for ${symbol}`,
+        details: {
+          provider: this.id,
+          interval
+        }
+      } as APIError;
+    }
+
+    const startDate = new Date(normalizedCandles[0].timestamp).toISOString();
+    const endDate = new Date(
+      normalizedCandles[normalizedCandles.length - 1].timestamp
+    ).toISOString();
+    const range: TimeRange = {
+      startDate,
+      endDate,
+      interval
+    };
+
+    return {
+      symbol: normalizeSymbol(symbol),
+      range,
+      candles: normalizedCandles,
+      lastUpdated: endDate
+    };
+  }
+
+  async healthCheck(): Promise<ProviderHealthCheck> {
+    const startedAt = this.now();
+    const checkedAt = new Date(startedAt).toISOString();
+
+    try {
+      await this.fetchChart(this.healthSymbol, {
+        range: '1d',
+        interval: '1d'
+      });
+
+      return {
+        provider: this.name,
+        providerId: this.id,
+        status: 'healthy',
+        latencyMs: Math.max(0, this.now() - startedAt),
+        checkedAt,
+        details: {
+          symbol: this.healthSymbol
+        }
+      };
+    } catch (error) {
+      const apiError = this.isAPIError(error)
+        ? error
+        : this.createAPIError(error, 'Yahoo Finance health check failed');
+
+      return {
+        provider: this.name,
+        providerId: this.id,
+        status: 'degraded',
+        latencyMs: Math.max(0, this.now() - startedAt),
+        checkedAt,
+        details: {
+          code: apiError.code,
+          message: apiError.message,
+          retryAfter:
+            typeof apiError.details?.retryAfter === 'number'
+              ? apiError.details.retryAfter
+              : undefined
+        }
+      };
+    }
+  }
+
+  private async fetchChart(
+    symbol: string,
+    params: Record<string, string>
+  ): Promise<YahooChartFetchResult> {
+    const yahooSymbol = this.toYahooSymbol(symbol);
+    const url = new URL(
+      `${YAHOO_CHART_BASE_URL}/${encodeURIComponent(yahooSymbol)}`
+    );
+
+    Object.entries(params).forEach(([key, value]) => {
+      url.searchParams.set(key, value);
+    });
+
+    let response: Response;
+
+    try {
+      response = await this.fetchImpl(url.toString(), {
+        cache: 'no-store'
+      });
+    } catch (error) {
+      throw this.createAPIError(error, 'Yahoo Finance network request failed');
+    }
+
+    const payload = await readYahooChartResponse(response);
+
+    if (!response.ok) {
+      throw this.createHTTPError(response, payload);
+    }
+
+    const providerError = payload?.chart?.error;
+    if (providerError) {
+      throw this.createProviderError(providerError);
+    }
+
+    const result = payload?.chart?.result?.[0];
+    if (!result) {
+      throw {
+        code: 'INVALID_SYMBOL',
+        message: `Yahoo Finance symbol was not found or is unsupported: ${symbol}`,
+        details: {
+          provider: this.id,
+          symbol: yahooSymbol
+        }
+      } as APIError;
+    }
+
+    return {
+      result,
+      yahooSymbol
+    };
+  }
+
+  private transformChartResultToCandles(
+    result: YahooChartResult
+  ): KLineCandle[] {
+    const timestamps = result.timestamp ?? [];
+    const quote = result.indicators?.quote?.[0] ?? {};
+
+    return timestamps
+      .map((timestamp, index) => {
+        const open = getArrayNumber(quote.open, index);
+        const high = getArrayNumber(quote.high, index);
+        const low = getArrayNumber(quote.low, index);
+        const close = getArrayNumber(quote.close, index);
+        const volume = getArrayNumber(quote.volume, index);
+
+        if (
+          open === undefined ||
+          high === undefined ||
+          low === undefined ||
+          close === undefined
+        ) {
+          return null;
+        }
+
+        return {
+          timestamp: timestamp * 1000,
+          open,
+          high,
+          low,
+          close,
+          volume: volume ?? 0
+        };
+      })
+      .filter((candle): candle is KLineCandle => candle !== null)
+      .sort((a, b) => a.timestamp - b.timestamp);
+  }
+
+  private toYahooSymbol(symbol: string): string {
+    const normalized = normalizeSymbol(symbol);
+
+    if (normalized.endsWith('.US')) {
+      return normalized.slice(0, -3);
+    }
+
+    return normalized;
+  }
+
+  private createHTTPError(
+    response: Response,
+    payload: YahooChartResponse | null
+  ): APIError {
+    const message =
+      payload?.chart?.error?.description ||
+      response.statusText ||
+      'Yahoo Finance request failed';
+    const retryAfter = parseRetryAfter(response.headers.get('Retry-After'));
+    const details: Record<string, unknown> = {
+      provider: this.id,
+      statusCode: response.status
+    };
+
+    if (retryAfter) {
+      details.retryAfter = retryAfter;
+    }
+
+    if (response.status === 429) {
+      return {
+        code: 'API_LIMIT_EXCEEDED',
+        message: 'Yahoo Finance rate limit exceeded. Please try again shortly.',
+        details
+      };
+    }
+
+    if (response.status === 404) {
+      return {
+        code: 'INVALID_SYMBOL',
+        message,
+        details
+      };
+    }
+
+    if (response.status >= 500) {
+      return {
+        code: 'NETWORK_ERROR',
+        message: 'Yahoo Finance upstream service failed',
+        details
+      };
+    }
+
+    return {
+      code: 'UNKNOWN_ERROR',
+      message,
+      details
+    };
+  }
+
+  private createProviderError(error: YahooChartError): APIError {
+    const description = error.description || 'Yahoo Finance request failed';
+    const normalized = `${error.code ?? ''} ${description}`.toLowerCase();
+
+    if (
+      normalized.includes('not found') ||
+      normalized.includes('no data') ||
+      normalized.includes('invalid symbol')
+    ) {
+      return {
+        code: 'INVALID_SYMBOL',
+        message: description,
+        details: {
+          provider: this.id,
+          upstreamCode: error.code
+        }
+      };
+    }
+
+    if (
+      normalized.includes('rate limit') ||
+      normalized.includes('too many request') ||
+      normalized.includes('quota')
+    ) {
+      return {
+        code: 'API_LIMIT_EXCEEDED',
+        message: 'Yahoo Finance rate limit exceeded. Please try again shortly.',
+        details: {
+          provider: this.id,
+          upstreamCode: error.code
+        }
+      };
+    }
+
+    return {
+      code: 'UNKNOWN_ERROR',
+      message: description,
+      details: {
+        provider: this.id,
+        upstreamCode: error.code
+      }
+    };
+  }
+
+  private createAPIError(error: unknown, message: string): APIError {
+    const details: Record<string, unknown> = {
+      provider: this.id
+    };
+
+    if (error instanceof Error) {
+      details.upstream = {
+        name: error.name,
+        message: error.message
+      };
+    }
+
+    return {
+      code: 'NETWORK_ERROR',
+      message,
+      details
+    };
+  }
+
+  private isAPIError(error: unknown): error is APIError {
+    return (
+      error !== null &&
+      typeof error === 'object' &&
+      'code' in error &&
+      'message' in error
+    );
+  }
+}
+
+async function readYahooChartResponse(
+  response: Response
+): Promise<YahooChartResponse | null> {
+  try {
+    return (await response.json()) as YahooChartResponse;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeSymbol(symbol: string): string {
+  return symbol.trim().toUpperCase();
+}
+
+function getLatestIndex(values?: Array<number | null>): number {
+  if (!values) return -1;
+
+  for (let index = values.length - 1; index >= 0; index -= 1) {
+    if (typeof values[index] === 'number' && Number.isFinite(values[index])) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+function getArrayNumber(
+  values: Array<number | null> | undefined,
+  index: number
+): number | undefined {
+  if (!values || index < 0) return undefined;
+
+  const value = values[index];
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function getPreviousNumber(
+  values: Array<number | null> | undefined,
+  index: number
+): number | undefined {
+  if (!values || index <= 0) return undefined;
+
+  for (let previousIndex = index - 1; previousIndex >= 0; previousIndex -= 1) {
+    const value = getArrayNumber(values, previousIndex);
+    if (value !== undefined) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function firstNumber(
+  ...values: Array<number | null | undefined>
+): number | undefined {
+  return values.find(
+    (value): value is number =>
+      typeof value === 'number' && Number.isFinite(value)
+  );
+}
+
+function aggregateCandlesByYear(candles: KLineCandle[]): KLineCandle[] {
+  const groups = new Map<number, KLineCandle>();
+
+  candles.forEach((candle) => {
+    const year = new Date(candle.timestamp).getUTCFullYear();
+    const existing = groups.get(year);
+
+    if (!existing) {
+      groups.set(year, {
+        timestamp: Date.UTC(year, 0, 1),
+        open: candle.open,
+        high: candle.high,
+        low: candle.low,
+        close: candle.close,
+        volume: candle.volume
+      });
+      return;
+    }
+
+    groups.set(year, {
+      ...existing,
+      high: Math.max(existing.high, candle.high),
+      low: Math.min(existing.low, candle.low),
+      close: candle.close,
+      volume: existing.volume + candle.volume
+    });
+  });
+
+  return Array.from(groups.values()).sort((a, b) => a.timestamp - b.timestamp);
+}
+
+function parseRetryAfter(value: string | null): number | undefined {
+  if (!value?.trim()) return undefined;
+
+  const numericValue = Number(value);
+  if (Number.isFinite(numericValue)) {
+    return Math.ceil(numericValue);
+  }
+
+  const dateValue = Date.parse(value);
+  if (!Number.isNaN(dateValue)) {
+    return Math.ceil((dateValue - Date.now()) / 1000);
+  }
+
+  return undefined;
+}

--- a/src/lib/validation/ticker.ts
+++ b/src/lib/validation/ticker.ts
@@ -1,7 +1,13 @@
+const BARE_TICKER_PATTERN = /^[A-Z]{1,5}$/;
+const QUALIFIED_TICKER_PATTERN = /^[A-Z0-9]{1,6}\.(US|HK|SS|SZ|CN)$/;
+
 export function isValidTicker(symbol: string): boolean {
   if (!symbol) return false;
   const normalized = symbol.trim().toUpperCase();
-  return /^[A-Z]{1,5}$/.test(normalized);
+  return (
+    BARE_TICKER_PATTERN.test(normalized) ||
+    QUALIFIED_TICKER_PATTERN.test(normalized)
+  );
 }
 
 export function normalizeTicker(symbol: string): string {
@@ -17,20 +23,38 @@ export function validateTicker(symbol: string): {
   }
 
   const trimmed = symbol.trim();
+  const normalized = trimmed.toUpperCase();
   if (trimmed.length === 0) {
     return { isValid: false, error: 'Ticker symbol is required' };
   }
 
-  if (trimmed.length > 5) {
+  if (isValidTicker(normalized)) {
+    return { isValid: true };
+  }
+
+  if (!/^[A-Za-z0-9.]+$/.test(trimmed)) {
     return {
       isValid: false,
-      error: 'Ticker symbol must be 5 characters or less'
+      error: 'Ticker symbol must contain only letters, numbers, or one dot'
     };
   }
 
-  if (!/^[A-Za-z]+$/.test(trimmed)) {
-    return { isValid: false, error: 'Ticker symbol must contain only letters' };
+  if ((trimmed.match(/\./g) ?? []).length > 1) {
+    return {
+      isValid: false,
+      error: 'Ticker symbol must include at most one market suffix'
+    };
   }
 
-  return { isValid: true };
+  if (trimmed.includes('.')) {
+    return {
+      isValid: false,
+      error: 'Market-qualified symbols must look like AAPL.US or 0700.HK'
+    };
+  }
+
+  return {
+    isValid: false,
+    error: 'Ticker symbol must be 1-5 letters'
+  };
 }


### PR DESCRIPTION
## Summary
- Add a provider registry with `auto`, `longbridge`, and `yahoo` routing, plus market-aware fallback selection
- Introduce a Yahoo Finance adapter and an auto fallback provider that records fallback attempts and provider health metadata
- Update health reporting, dashboard source selection, diagnostics, ticker validation, and docs to reflect multi-provider routing

## Testing
- Added and updated unit tests for registry routing, fallback behavior, Yahoo Finance mapping, health reporting, diagnostics, and dashboard UI state
- Ran the full Jest suite, ESLint, TypeScript checks, and Prettier validation successfully