### PR TITLE
Fix pnpm workspace configuration for install

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - '.'
+
 onlyBuiltDependencies:
   - '@clerk/shared'
   - '@sentry/cli'


### PR DESCRIPTION
## Summary
- Add a root `packages` entry to `pnpm-workspace.yaml` so pnpm 10 accepts the workspace file during install
- Preserve the existing `onlyBuiltDependencies` allowlist used for builds

## Testing
- Verified `pnpm install --frozen-lockfile --ignore-scripts` completes successfully after the config change