### PR TITLE
Create Trellis tasks for five Stock Tracker Linear issues

### DIFF
--- a/.trellis/tasks/05-03-issue-001-portable-architecture-adr/prd.md
+++ b/.trellis/tasks/05-03-issue-001-portable-architecture-adr/prd.md
@@ -1,0 +1,45 @@
+# ISSUE-001 Create ADR for portable Stock Tracker architecture
+
+## Source
+
+- Linear issue: T-132
+- Linear URL: https://linear.app/linnkidchen/issue/T-132/issue-001-create-adr-for-portable-stock-tracker-architecture
+- Linear status: Done
+- Project: Stock Tracker
+- Milestone: Milestone 1 - Architecture and monorepo foundation
+- Priority: P0
+- Labels: p0, architecture, migration
+- Phase: Phase 0 - Migration governance
+- Depends on: none
+
+## Goal
+
+Create an ADR that defines the target portable architecture and prevents repeated technology direction debates.
+
+## Scope
+
+Create `docs/adr/001-portable-stock-tracker-architecture.md`.
+
+The ADR should define:
+
+- Frontend: Vite React SPA
+- API: Hono HTTP API, Node container by default
+- Market data: separate Node worker
+- Database: Postgres repository layer
+- Cache: Redis/Valkey abstraction
+- Auth: provider-neutral JWT/OIDC verifier
+- Contracts: OpenAPI and Zod schemas
+- Realtime: polling first, SSE later, WebSocket last
+- Deployment: Docker-first, cloud-portable
+
+## Acceptance Criteria
+
+- ADR explains why the project is moving away from Next.js full-stack coupling.
+- ADR explicitly states that business logic must not import Next, Hono, Cloudflare, Clerk, Supabase, or Sentry directly.
+- ADR defines the target runtime matrix: local Docker, Node container, optional serverless/edge.
+- ADR includes rollback principle: existing Next app remains operational until cutover.
+
+## Trellis Notes
+
+- Keep this as a documentation task.
+- Treat Linear status as source metadata only. Do not archive this Trellis task unless the corresponding repository work has been verified locally.

--- a/.trellis/tasks/05-03-issue-001-portable-architecture-adr/task.json
+++ b/.trellis/tasks/05-03-issue-001-portable-architecture-adr/task.json
@@ -1,0 +1,43 @@
+{
+  "id": "issue-001-portable-architecture-adr",
+  "name": "issue-001-portable-architecture-adr",
+  "title": "ISSUE-001 Create ADR for portable Stock Tracker architecture",
+  "description": "Linear T-132: create ADR for portable Stock Tracker architecture.",
+  "status": "planning",
+  "dev_type": "docs",
+  "scope": null,
+  "package": null,
+  "priority": "P0",
+  "creator": "tong-chen",
+  "assignee": "tong-chen",
+  "createdAt": "2026-05-03",
+  "completedAt": null,
+  "branch": null,
+  "base_branch": "main",
+  "worktree_path": null,
+  "commit": null,
+  "pr_url": null,
+  "subtasks": [],
+  "children": [],
+  "parent": null,
+  "relatedFiles": [
+    "docs/adr/001-portable-stock-tracker-architecture.md"
+  ],
+  "notes": "",
+  "meta": {
+    "linear": {
+      "issueId": "T-132",
+      "planId": "ISSUE-001",
+      "url": "https://linear.app/linnkidchen/issue/T-132/issue-001-create-adr-for-portable-stock-tracker-architecture",
+      "status": "Done",
+      "labels": [
+        "p0",
+        "architecture",
+        "migration"
+      ],
+      "project": "Stock Tracker",
+      "milestone": "Milestone 1 - Architecture and monorepo foundation",
+      "dependsOn": []
+    }
+  }
+}

--- a/.trellis/tasks/05-03-issue-003-current-next-api-baseline/prd.md
+++ b/.trellis/tasks/05-03-issue-003-current-next-api-baseline/prd.md
@@ -1,0 +1,51 @@
+# ISSUE-003 Document existing Next API behavior and response shapes
+
+## Source
+
+- Linear issue: T-134
+- Linear URL: https://linear.app/linnkidchen/issue/T-134/issue-003-document-existing-next-api-behavior-and-response-shapes
+- Linear status: In Progress
+- Project: Stock Tracker
+- Milestone: Milestone 1 - Architecture and monorepo foundation
+- Priority: P0
+- Labels: contracts, api, p0, migration
+- Phase: Phase 0 - Migration governance
+- Depends on: ISSUE-002
+
+## Goal
+
+Freeze current API request and response behavior before migrating API routes.
+
+## Scope
+
+Document current routes:
+
+- `GET /api/stocks/quote/[symbol]`
+- `GET /api/stocks/kline/[symbol]`
+- `GET /api/stocks/providers/health`
+- `GET /api/ws/prices`
+- `GET /api/watchlist`
+- `POST /api/watchlist`
+- `PATCH /api/watchlist`
+- `DELETE /api/watchlist`
+- `GET /api/portfolio/holdings`
+- `POST /api/portfolio/holdings`
+- `PATCH /api/portfolio/holdings/[id]`
+- `DELETE /api/portfolio/holdings/[id]`
+- `POST /api/log`
+
+Create:
+
+- `docs/migration/current-api-baseline.md`
+- `tests/fixtures/current-api/`
+
+## Acceptance Criteria
+
+- Each current route has documented input, output, error shape, and auth behavior.
+- Quote, kline, watchlist, and portfolio have fixture examples.
+- Existing API behavior is treated as compatibility baseline for the new `/v1` API.
+
+## Trellis Notes
+
+- Confirm whether ISSUE-002 is represented by an existing Trellis task before starting implementation.
+- This task should inspect current code and fixtures before drafting documentation.

--- a/.trellis/tasks/05-03-issue-003-current-next-api-baseline/task.json
+++ b/.trellis/tasks/05-03-issue-003-current-next-api-baseline/task.json
@@ -1,0 +1,47 @@
+{
+  "id": "issue-003-current-next-api-baseline",
+  "name": "issue-003-current-next-api-baseline",
+  "title": "ISSUE-003 Document existing Next API behavior and response shapes",
+  "description": "Linear T-134: document current Next API behavior, response shapes, auth, errors, and fixtures.",
+  "status": "planning",
+  "dev_type": "docs",
+  "scope": null,
+  "package": null,
+  "priority": "P0",
+  "creator": "tong-chen",
+  "assignee": "tong-chen",
+  "createdAt": "2026-05-03",
+  "completedAt": null,
+  "branch": null,
+  "base_branch": "main",
+  "worktree_path": null,
+  "commit": null,
+  "pr_url": null,
+  "subtasks": [],
+  "children": [],
+  "parent": null,
+  "relatedFiles": [
+    "docs/migration/current-api-baseline.md",
+    "tests/fixtures/current-api/"
+  ],
+  "notes": "",
+  "meta": {
+    "linear": {
+      "issueId": "T-134",
+      "planId": "ISSUE-003",
+      "url": "https://linear.app/linnkidchen/issue/T-134/issue-003-document-existing-next-api-behavior-and-response-shapes",
+      "status": "In Progress",
+      "labels": [
+        "contracts",
+        "api",
+        "p0",
+        "migration"
+      ],
+      "project": "Stock Tracker",
+      "milestone": "Milestone 1 - Architecture and monorepo foundation",
+      "dependsOn": [
+        "ISSUE-002"
+      ]
+    }
+  }
+}

--- a/.trellis/tasks/05-03-issue-004-apps-packages-pnpm-workspace/prd.md
+++ b/.trellis/tasks/05-03-issue-004-apps-packages-pnpm-workspace/prd.md
@@ -1,0 +1,48 @@
+# ISSUE-004 Convert repo to apps/packages pnpm workspace
+
+## Source
+
+- Linear issue: T-135
+- Linear URL: https://linear.app/linnkidchen/issue/T-135/issue-004-convert-repo-to-appspackages-pnpm-workspace
+- Linear status: Todo
+- Project: Stock Tracker
+- Milestone: Milestone 1 - Architecture and monorepo foundation
+- Priority: P0
+- Labels: infra, monorepo, p0
+- Phase: Phase 1 - Monorepo + contracts + domain boundaries
+- Depends on: ISSUE-003
+
+## Goal
+
+Move from the current single-package workspace to a real monorepo for `apps/web`, `apps/api`, `apps/market-data-worker`, and shared packages.
+
+## Scope
+
+Restructure to:
+
+- `apps/next-legacy/`
+- `packages/placeholder/`
+
+Move the existing Next app into `apps/next-legacy/`.
+
+Update:
+
+- `pnpm-workspace.yaml`
+- `package.json`
+- `tsconfig.base.json`
+- eslint config
+- prettier config
+- jest config
+- playwright config
+
+## Acceptance Criteria
+
+- Existing Next app still runs from `apps/next-legacy`.
+- Existing tests still pass or failures are explicitly documented.
+- Root `package.json` has workspace-level scripts.
+- No business logic changes in this issue.
+
+## Trellis Notes
+
+- Confirm ISSUE-003 is complete before starting this task.
+- Keep the change mechanical and avoid feature behavior changes.

--- a/.trellis/tasks/05-03-issue-004-apps-packages-pnpm-workspace/task.json
+++ b/.trellis/tasks/05-03-issue-004-apps-packages-pnpm-workspace/task.json
@@ -1,0 +1,53 @@
+{
+  "id": "issue-004-apps-packages-pnpm-workspace",
+  "name": "issue-004-apps-packages-pnpm-workspace",
+  "title": "ISSUE-004 Convert repo to apps/packages pnpm workspace",
+  "description": "Linear T-135: convert current repository into apps/packages pnpm workspace without business logic changes.",
+  "status": "planning",
+  "dev_type": "infra",
+  "scope": null,
+  "package": null,
+  "priority": "P0",
+  "creator": "tong-chen",
+  "assignee": "tong-chen",
+  "createdAt": "2026-05-03",
+  "completedAt": null,
+  "branch": null,
+  "base_branch": "main",
+  "worktree_path": null,
+  "commit": null,
+  "pr_url": null,
+  "subtasks": [],
+  "children": [],
+  "parent": null,
+  "relatedFiles": [
+    "apps/next-legacy/",
+    "packages/placeholder/",
+    "pnpm-workspace.yaml",
+    "package.json",
+    "tsconfig.base.json",
+    "eslint config",
+    "prettier config",
+    "jest config",
+    "playwright config"
+  ],
+  "notes": "",
+  "meta": {
+    "linear": {
+      "issueId": "T-135",
+      "planId": "ISSUE-004",
+      "url": "https://linear.app/linnkidchen/issue/T-135/issue-004-convert-repo-to-appspackages-pnpm-workspace",
+      "status": "Todo",
+      "labels": [
+        "infra",
+        "monorepo",
+        "p0"
+      ],
+      "project": "Stock Tracker",
+      "milestone": "Milestone 1 - Architecture and monorepo foundation",
+      "dependsOn": [
+        "ISSUE-003"
+      ]
+    }
+  }
+}

--- a/.trellis/tasks/05-03-issue-006-api-contract-package/prd.md
+++ b/.trellis/tasks/05-03-issue-006-api-contract-package/prd.md
@@ -1,0 +1,55 @@
+# ISSUE-006 Create API contract package with shared schemas
+
+## Source
+
+- Linear issue: T-137
+- Linear URL: https://linear.app/linnkidchen/issue/T-137/issue-006-create-api-contract-package-with-shared-schemas
+- Linear status: In Progress
+- Project: Stock Tracker
+- Milestone: Milestone 1 - Architecture and monorepo foundation
+- Priority: P0
+- Labels: contracts, api, p0
+- Phase: Phase 1 - Monorepo + contracts + domain boundaries
+- Depends on: ISSUE-005
+
+## Goal
+
+Create shared schemas and types for all API surfaces.
+
+## Scope
+
+Create `packages/contracts/` with:
+
+- `src/quote.ts`
+- `src/kline.ts`
+- `src/provider-health.ts`
+- `src/watchlist.ts`
+- `src/portfolio.ts`
+- `src/errors.ts`
+- `src/pagination.ts`
+- `src/index.ts`
+
+Define schemas:
+
+- `StockQuote`
+- `BatchQuoteResponse`
+- `KLineRequest`
+- `KLineSeries`
+- `ProviderHealth`
+- `Watchlist`
+- `WatchlistItem`
+- `PortfolioHolding`
+- `PortfolioSummary`
+- `APIError`
+
+## Acceptance Criteria
+
+- Zod schemas exist for quote, kline, provider health, watchlist, portfolio, and errors.
+- Types are inferred from schemas.
+- Existing Next app can import the package without circular dependency.
+- Package has unit tests for schema parsing.
+
+## Trellis Notes
+
+- Confirm ISSUE-005 has established shared TypeScript, lint, and package conventions before starting implementation.
+- This package should be framework-independent and safe for both app and server imports.

--- a/.trellis/tasks/05-03-issue-006-api-contract-package/task.json
+++ b/.trellis/tasks/05-03-issue-006-api-contract-package/task.json
@@ -1,0 +1,45 @@
+{
+  "id": "issue-006-api-contract-package",
+  "name": "issue-006-api-contract-package",
+  "title": "ISSUE-006 Create API contract package with shared schemas",
+  "description": "Linear T-137: create packages/contracts with shared Zod schemas and inferred API types.",
+  "status": "planning",
+  "dev_type": "feature",
+  "scope": null,
+  "package": null,
+  "priority": "P0",
+  "creator": "tong-chen",
+  "assignee": "tong-chen",
+  "createdAt": "2026-05-03",
+  "completedAt": null,
+  "branch": null,
+  "base_branch": "main",
+  "worktree_path": null,
+  "commit": null,
+  "pr_url": null,
+  "subtasks": [],
+  "children": [],
+  "parent": null,
+  "relatedFiles": [
+    "packages/contracts/"
+  ],
+  "notes": "",
+  "meta": {
+    "linear": {
+      "issueId": "T-137",
+      "planId": "ISSUE-006",
+      "url": "https://linear.app/linnkidchen/issue/T-137/issue-006-create-api-contract-package-with-shared-schemas",
+      "status": "In Progress",
+      "labels": [
+        "contracts",
+        "api",
+        "p0"
+      ],
+      "project": "Stock Tracker",
+      "milestone": "Milestone 1 - Architecture and monorepo foundation",
+      "dependsOn": [
+        "ISSUE-005"
+      ]
+    }
+  }
+}

--- a/.trellis/tasks/05-03-issue-008-domain-package-use-cases/prd.md
+++ b/.trellis/tasks/05-03-issue-008-domain-package-use-cases/prd.md
@@ -1,0 +1,67 @@
+# ISSUE-008 Create domain package for business use cases
+
+## Source
+
+- Linear issue: T-139
+- Linear URL: https://linear.app/linnkidchen/issue/T-139/issue-008-create-domain-package-for-business-use-cases
+- Linear status: Todo
+- Project: Stock Tracker
+- Milestone: Milestone 1 - Architecture and monorepo foundation
+- Priority: P0
+- Labels: domain, p0, architecture
+- Phase: Phase 1 - Monorepo + contracts + domain boundaries
+- Depends on: ISSUE-006
+
+## Goal
+
+Move business logic out of framework adapters.
+
+## Scope
+
+Create `packages/domain/` with:
+
+- `src/quotes/`
+- `src/klines/`
+- `src/watchlist/`
+- `src/portfolio/`
+- `src/providers/`
+- `src/rate-limit/`
+- `src/errors/`
+- `src/index.ts`
+
+Define ports:
+
+- `MarketDataProvider`
+- `QuoteCache`
+- `KLineCache`
+- `WatchlistRepository`
+- `PortfolioRepository`
+- `RateLimiter`
+- `AuthContext`
+- `Logger`
+- `Clock`
+
+Define use cases:
+
+- `getBatchQuotes`
+- `getKLines`
+- `getProviderHealth`
+- `getDefaultWatchlist`
+- `replaceDefaultWatchlist`
+- `addWatchlistItem`
+- `removeWatchlistItem`
+- `getPortfolioHoldings`
+- `createPortfolioHolding`
+- `updatePortfolioHolding`
+- `deletePortfolioHolding`
+
+## Acceptance Criteria
+
+- Domain package imports contracts but does not import Next, Hono, Clerk, Supabase, Redis, Sentry, or Cloudflare.
+- Use cases are testable with in-memory fake adapters.
+- Unit tests cover quote cache hit, quote cache miss, provider fallback, watchlist ownership, and portfolio ownership.
+
+## Trellis Notes
+
+- Confirm ISSUE-006 is complete before starting this task.
+- Keep domain logic framework-independent. Adapter-specific packages should depend on the domain, not the reverse.

--- a/.trellis/tasks/05-03-issue-008-domain-package-use-cases/task.json
+++ b/.trellis/tasks/05-03-issue-008-domain-package-use-cases/task.json
@@ -1,0 +1,45 @@
+{
+  "id": "issue-008-domain-package-use-cases",
+  "name": "issue-008-domain-package-use-cases",
+  "title": "ISSUE-008 Create domain package for business use cases",
+  "description": "Linear T-139: create packages/domain with framework-independent ports and business use cases.",
+  "status": "planning",
+  "dev_type": "feature",
+  "scope": null,
+  "package": null,
+  "priority": "P0",
+  "creator": "tong-chen",
+  "assignee": "tong-chen",
+  "createdAt": "2026-05-03",
+  "completedAt": null,
+  "branch": null,
+  "base_branch": "main",
+  "worktree_path": null,
+  "commit": null,
+  "pr_url": null,
+  "subtasks": [],
+  "children": [],
+  "parent": null,
+  "relatedFiles": [
+    "packages/domain/"
+  ],
+  "notes": "",
+  "meta": {
+    "linear": {
+      "issueId": "T-139",
+      "planId": "ISSUE-008",
+      "url": "https://linear.app/linnkidchen/issue/T-139/issue-008-create-domain-package-for-business-use-cases",
+      "status": "Todo",
+      "labels": [
+        "domain",
+        "p0",
+        "architecture"
+      ],
+      "project": "Stock Tracker",
+      "milestone": "Milestone 1 - Architecture and monorepo foundation",
+      "dependsOn": [
+        "ISSUE-006"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Added five new Trellis task directories for `ISSUE-001`, `ISSUE-003`, `ISSUE-004`, `ISSUE-006`, and `ISSUE-008`.
- Populated each task with a `prd.md` and `task.json` carrying the Linear issue metadata, scope, dependencies, and acceptance criteria.
- Kept the tasks in `planning` state so they are ready for the normal Trellis planning/execute flow.

## Testing
- Ran Trellis task validation for all five tasks; each passed.
- Verified the new task files exist under `.trellis/tasks/`.